### PR TITLE
add support for 404 error pages tracking #6

### DIFF
--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -48,5 +48,13 @@ class Actions {
 		}
 
 		wp_enqueue_script( 'plausible-analytics', Helpers::get_analytics_url(), '', PLAUSIBLE_ANALYTICS_VERSION );
+
+		// Goal tracking inline script (Don't disable this as it is required by 404).
+		wp_add_inline_script( 'plausible-analytics', 'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }' );
+
+		// Track 404 pages.
+		if ( apply_filters( 'plausible_analytics_enable_404', true ) && is_404() ) {
+			wp_add_inline_script( 'plausible-analytics', 'plausible("404",{ props: { path: document.location.pathname } });' );
+		}
 	}
 }


### PR DESCRIPTION
This PR resolves #6 

This PR also includes support for #4 and #3. But, I will test those issues with `develop` branch again and then will update accordingly.

## Visuals
![image](https://user-images.githubusercontent.com/1852711/101942784-15557f00-3c10-11eb-91a7-d991ba4fa67a.png)

@metmarkosaric I assume that we should keep 404 tracking functionality enabled by default so I have not provided any admin settings to disable it as tracking custom events and 404 will be essential need these days. But, I have provided a WP filter to disable it.

Can you please review the PR and merge if it looks good? 

## Suggestion
@metmarkosaric I have a suggestion that if we include some default goals whenever a user add a site on plausible.io then it will be plug'n'play functionality for users using the plugin. See screenshot for what screen I am talking about.

![image](https://user-images.githubusercontent.com/1852711/101943200-b5130d00-3c10-11eb-865f-56f8d1d3a75d.png)

For example, 404 goal will be automatically added when we add a site. So, installing this plugin will be enough without any configuration. 

What do you think?