### PR TITLE
add support for outbound link click tracking #4

### DIFF
--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -56,5 +56,10 @@ class Actions {
 		if ( apply_filters( 'plausible_analytics_enable_404', true ) && is_404() ) {
 			wp_add_inline_script( 'plausible-analytics', 'plausible("404",{ props: { path: document.location.pathname } });' );
 		}
+
+		// Track Outbound Links.
+		if ( apply_filters( 'plausible_analytics_enable_outbound_links', true ) ) {
+			wp_add_inline_script( 'plausible-analytics', 'document.addEventListener("click",function(e){for(var t=e.target;t&&(void 0===t.tagName||"a"!=t.tagName.toLowerCase()||!t.href);)t=t.parentNode;t&&t.href&&t.host&&t.host!==location.host&&(plausible("Outbound Link: Click",{props:{referrer:document.location.origin,url:t.href}}),t.target&&!t.target.match(/^_(self|parent|top)$/i)||(setTimeout(function(){location.href=t.href},150),e.preventDefault()))});' );
+		}
 	}
 }


### PR DESCRIPTION
This PR resolves #4 

@metmarkosaric I have implemented this functionality using a custom snippet (minified) based on code here: https://github.com/plausible/analytics/blob/1504dd5412e2aad006c7ec669c342c649b1da186/tracker/src/plausible.js#L59-L76

I have tested this and is working as expected. But, I want you to take a look on this PR as well and merge the PR if it looks good to you.

## Visuals
**Breakdown: URL**
![image](https://user-images.githubusercontent.com/1852711/101986885-cd3d6780-3cb6-11eb-86da-75b217707ab6.png)

**Breakdown: Referrer**
![image](https://user-images.githubusercontent.com/1852711/101986903-e9410900-3cb6-11eb-9238-42a436904447.png)

I think if we agree to go with custom snippet for Outbound links then we can add it as a default goal for all new sites added to plausible.io.
