### PR TITLE
Add support for excluding pages

### DIFF
--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -32,6 +32,7 @@ class Page extends API {
 		$domain             = ! empty( $settings['domain_name'] ) ? $settings['domain_name'] : Helpers::get_domain();
 		$self_hosted_domain = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : 'example.com';
 		$shared_link        = ! empty( $settings['shared_link'] ) ? $settings['shared_link'] : "https://plausible.io/share/{$domain}?auth=XXXXXXXXXXXX";
+		$excluded_pages     = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : "/imprint, /privacy-policy";
 		$custom_domain      = ! empty( $settings['custom_domain'] ) ? $settings['custom_domain'] : "analytics.{$domain}";
 
 		$this->fields = [
@@ -103,6 +104,26 @@ class Page extends API {
 							'slug'  => 'shared_link',
 							'type'  => 'text',
 							'value' => $shared_link,
+						],
+					],
+				],
+				[
+					'label'  => esc_html__( 'Exclude specific pages from being tracked', 'plausible-analytics' ),
+					'slug'   => 'is_exclude_pages',
+					'type'   => 'group',
+					'desc'   => sprintf(
+						'%1$s <a href="%2$s" target="_blank">%3$s</a>',
+						esc_html__( 'Exclude certain pages from being tracked', 'plausible-analytics' ),
+						esc_url( 'https://plausible.io/docs/excluding-pages#2-add-the-pages-youd-like-to-exclude-from-being-tracked' ),
+						esc_html__( 'See syntax &raquo;', 'plausible-analytics' )
+					),
+					'toggle' => true,
+					'fields' => [
+						[
+							'label' => esc_html__( 'Excluded pages', 'plausible-analytics' ),
+							'slug'  => 'excluded_pages',
+							'type'  => 'text',
+							'value' => $excluded_pages,
 						],
 					],
 				],

--- a/src/Includes/Filters.php
+++ b/src/Includes/Filters.php
@@ -37,7 +37,7 @@ class Filters {
 	 * @since  1.0.0
 	 * @access public
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function add_plausible_attributes( $tag, $handle ) {
 		// Bailout, if not `Plausible Analytics` script.
@@ -45,10 +45,18 @@ class Filters {
 			return $tag;
 		}
 
-		$settings    = Helpers::get_settings();
-		$api_url     = Helpers::get_data_api_url();
-		$domain_name = $settings['domain_name'];
+		$settings       = Helpers::get_settings();
+		$api_url        = Helpers::get_data_api_url();
+		$domain_name    = $settings['domain_name'];
 
-		return str_replace( ' src', " async defer data-domain='{$domain_name}' data-api='{$api_url}' src", $tag );
+		$params = "async defer data-domain='{$domain_name}' data-api='{$api_url}'";
+
+		// Triggered when exclude pages is enabled.
+		if ( ! empty( $settings['is_exclude_pages'] ) && $settings['is_exclude_pages'] ) {
+			$excluded_pages = $settings['excluded_pages'];
+			$params .= " data-exclude='{$excluded_pages}'";
+		}
+
+		return str_replace( ' src', " {$params} src", $tag );
 	}
 }


### PR DESCRIPTION
This PR resolves #58

First time working with this codebase, feedback is appreciated :wink: 

I wasn't sure about the `.pot` file. Do I need to change something there?

## Visuals

![image](https://user-images.githubusercontent.com/54544490/156366845-6b1cfe07-292b-4035-baa5-0b53533f3879.png)

## Off-topic

I noticed that `'true' === $settings['is_self_hosted_analytics']` is being used but for me, it wasn't `'true'` but `'1'`. This also broke self-hosted support in my setup. Is it a bug?