### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To get started developing on the Plausible Analytics WordPress Plugin you will n
 
 3. Clone this repository from GitHub into your plugins directory: `https://github.com/plausible/wordpress.git`
 
-4. Run composer to set up dependancies: `composer install`
+4. Run composer to set up dependencies: `composer install`
 
 5. Run npm install to get the necessary npm packages: `npm install`
 


### PR DESCRIPTION
This should be self-explanatory.
Another thing I noticed: I tried to use Node 16 (The latest LTS) but got an error when trying to `npm install`. It worked with Node 12 though. Maybe the supported/recommended Node version should be noted somewhere in the README