### PR TITLE
Add artifact task

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -40,6 +40,7 @@ package.json
 package-lock.json
 phpunit.xml
 phpunit.xml.dist
+plausible-analytics.zip
 CHANGELOG.md
 README.md
 readme.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ wp-textdomain.js export-ignore
 README.md export-ignore
 tests export-ignore
 node_modules export-ignore
+plausible-analytics.zip export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ assets/dist/
 
 # Composer
 vendor
+
+# Artifact file
+plausible-analytics.zip

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "lint:php": "./vendor/bin/phpcs --colors --standard=phpcs.ruleset.xml",
         "lint:php:fix": "./vendor/bin/phpcbf --colors --standard=phpcs.ruleset.xml",
         "lint:textdomain": "node ./wp-textdomain.js",
-        "lint:scss": "stylelint assets/src/**/*.scss"
+        "lint:scss": "stylelint assets/src/**/*.scss",
+        "artifact": "mkdir release && mkdir release/plausible-analytics && rsync -rc --exclude-from=\"./.distignore\" \"./\" release/plausible-analytics/ --delete --delete-excluded && cd release && zip -r ../plausible-analytics.zip * && cd .. && rm -rf release"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Adds an artifact task that creates a testable `plausible-analytics.zip` file in the root that, when unzipped, creates a `plausible-analytics` folder, so it's nice and easy to install on test sites.