### PR TITLE
Make composer install work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,11 @@
         "psr-4": {
             "Plausible\\Analytics\\WP\\": "src/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
When running `composer install` you'd get an error because these two plugins aren't in the `composer.json` as allowed plugins. They should be. This fixes that.