### PR TITLE
Add search tracking

### DIFF
--- a/assets/src/css/admin/general.scss
+++ b/assets/src/css/admin/general.scss
@@ -5,6 +5,8 @@
 		background-color: #f5f5f5;
 		border: none;
 		border-radius: 5px;
+		min-width: 300px;
+		margin: 5px 0 5px 5px;
 	}
 
 	input[name='shared_link'] {

--- a/languages/plausible-analytics.pot
+++ b/languages/plausible-analytics.pot
@@ -15,7 +15,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:72
+#: src/Admin/Actions.php:79
 msgid "Settings saved successfully."
 msgstr ""
 
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Thanks :)"
 msgstr ""
 
-#: src/Admin/Filters.php:67, src/Includes/Actions.php:106, src/Admin/Settings/Page.php:257
+#: src/Admin/Filters.php:67, src/Includes/Actions.php:106, src/Admin/Settings/Page.php:330
 msgid "Settings"
 msgstr ""
 
@@ -44,19 +44,19 @@ msgstr ""
 msgid "View Page Analytics"
 msgstr ""
 
-#: src/Includes/Helpers.php:164
+#: src/Includes/Helpers.php:205, src/Admin/Settings/Page.php:74, src/Admin/Settings/Page.php:96, src/Admin/Settings/Page.php:104
 msgid "Documentation"
 msgstr ""
 
-#: src/Includes/Helpers.php:168
+#: src/Includes/Helpers.php:209
 msgid "Report an issue"
 msgstr ""
 
-#: src/Includes/Helpers.php:172
+#: src/Includes/Helpers.php:213
 msgid "Translate Plugin"
 msgstr ""
 
-#: src/Includes/Helpers.php:195
+#: src/Includes/Helpers.php:236
 msgid "Quick Links"
 msgstr ""
 
@@ -68,142 +68,191 @@ msgstr ""
 msgid "Saved!"
 msgstr ""
 
-#: src/Admin/Settings/API.php:122
-msgid "Open Analytics"
-msgstr ""
-
-#: src/Admin/Settings/Page.php:40
+#: src/Admin/Settings/Page.php:42
 msgid "Connect your website with Plausible Analytics"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:45
+#: src/Admin/Settings/Page.php:47
 msgid "We have fetched the domain name for which Plausible Analytics will be used. We assume that you have already setup the domain on our website."
 msgstr ""
 
-#: src/Admin/Settings/Page.php:47
+#: src/Admin/Settings/Page.php:49
 msgid "Follow these instructions"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:48
+#: src/Admin/Settings/Page.php:50
 msgid "to add your site to Plausible."
 msgstr ""
 
-#: src/Admin/Settings/Page.php:53, src/Admin/Settings/Page.php:184
+#: src/Admin/Settings/Page.php:54
+msgid "Open Analytics"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:58, src/Admin/Settings/Page.php:257
 msgid "Domain Name"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:61
-msgid "Setup custom domain with Plausible Analytics"
-msgstr ""
-
 #: src/Admin/Settings/Page.php:66
-msgid "Enable the custom domain functionality in your Plausible account."
+msgid "Enhanced measurements"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:68, src/Admin/Settings/Page.php:93
-msgid "See how &raquo;"
-msgstr ""
-
-#: src/Admin/Settings/Page.php:69
-msgid "Enable this setting and configure it to link with Plausible Analytics on your custom domain."
+#. translators: %1$s replaced with <code>outbound-links</code>.
+#: src/Admin/Settings/Page.php:70
+msgid "Note:"
 msgstr ""
 
 #: src/Admin/Settings/Page.php:70
-msgid "For example,"
+msgid "for each of these extensions, you have to set the goals manually!"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:72
-msgid "or"
+#: src/Admin/Settings/Page.php:71
+msgid "By default, we load just the %1$s extension, you can enable other extensions here."
 msgstr ""
 
 #: src/Admin/Settings/Page.php:78
-msgid "Custom Domain"
+msgid "Outbound links"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:80, src/Admin/Settings/Page.php:88
+msgid "Goal setup"
 msgstr ""
 
 #: src/Admin/Settings/Page.php:86
-msgid "View your stats in your WordPress dashboard"
-msgstr ""
-
-#: src/Admin/Settings/Page.php:91
-msgid "Create a secure & private shared link in your Plausible account. Make sure the link is not password protected."
+msgid "File downloads"
 msgstr ""
 
 #: src/Admin/Settings/Page.php:94
-msgid "Enable this setting and paste your shared link to view your stats in your WordPress dashboard."
-msgstr ""
-
-#: src/Admin/Settings/Page.php:95
-msgid "View your site statistics within your WordPress Dashboard."
-msgstr ""
-
-#: src/Admin/Settings/Page.php:97
-msgid "View Statistics &raquo;"
+msgid "Hash-based routing"
 msgstr ""
 
 #: src/Admin/Settings/Page.php:102
-msgid "Shared Link"
+msgid "IE compatibility"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:110
-msgid "Track analytics for user roles"
-msgstr ""
-
-#: src/Admin/Settings/Page.php:113
-msgid "By default, we won't be tracking visits of any of the user roles listed above. If you want to track analytics for specific user roles then please check the specific user role setting."
+#: src/Admin/Settings/Page.php:112
+msgid "View your stats in your WordPress dashboard"
 msgstr ""
 
 #: src/Admin/Settings/Page.php:117
-msgid "Administrator"
+msgid "Create a secure & private shared link in your Plausible account. Make sure the link is not password protected."
 msgstr ""
 
-#: src/Admin/Settings/Page.php:123, src/Admin/Settings/Page.php:150
-msgid "Editor"
+#: src/Admin/Settings/Page.php:119, src/Admin/Settings/Page.php:223
+msgid "See how &raquo;"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:129, src/Admin/Settings/Page.php:156
-msgid "Author"
+#: src/Admin/Settings/Page.php:120
+msgid "Enable this setting and paste your shared link to view your stats in your WordPress dashboard."
 msgstr ""
 
-#: src/Admin/Settings/Page.php:135, src/Admin/Settings/Page.php:162
-msgid "Contributor"
+#: src/Admin/Settings/Page.php:121
+msgid "View your site statistics within your WordPress Dashboard."
+msgstr ""
+
+#: src/Admin/Settings/Page.php:123
+msgid "View Statistics &raquo;"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:128
+msgid "Shared Link"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:136
+msgid "Exclude specific pages from being tracked"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:141
+msgid "Exclude certain pages from being tracked"
 msgstr ""
 
 #: src/Admin/Settings/Page.php:143
+msgid "See syntax &raquo;"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:148
+msgid "Excluded pages"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:156
+msgid "Track analytics for user roles"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:159
+msgid "By default, we won't be tracking visits of any of the user roles listed above. If you want to track analytics for specific user roles then please check the specific user role setting."
+msgstr ""
+
+#: src/Admin/Settings/Page.php:163
+msgid "Administrator"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:169, src/Admin/Settings/Page.php:196
+msgid "Editor"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:175, src/Admin/Settings/Page.php:202
+msgid "Author"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:181, src/Admin/Settings/Page.php:208
+msgid "Contributor"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:189
 msgid "Show the stats dashboard to specific user roles"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:146
+#: src/Admin/Settings/Page.php:192
 msgid "By default, we are only showing the stats dashboard to admin users. If you want to allow the dashboard to be displayed for specific user roles, then please check them above."
 msgstr ""
 
-#: src/Admin/Settings/Page.php:172
+#: src/Admin/Settings/Page.php:216
+msgid "Run analytics script from a custom path"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:221
+msgid "Use a proxy to run Plausible and hide your tracking from ad blockers."
+msgstr ""
+
+#: src/Admin/Settings/Page.php:224
+msgid "Remove %1$s from your script URL and %2$s from your event API URL to get their paths."
+msgstr ""
+
+#: src/Admin/Settings/Page.php:229
+msgid "Script Path"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:235
+msgid "Event API Path"
+msgstr ""
+
+#: src/Admin/Settings/Page.php:245
 msgid "Self-hosted Plausible Analytics?"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:177
+#: src/Admin/Settings/Page.php:250
 msgid "If you're self-hosting Plausible on your own infrastructure, enter the domain name where you installed it to enable the integration with your self-hosted instance. Learn more"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:179
+#: src/Admin/Settings/Page.php:252
 msgid "about Plausible Self-Hosted."
 msgstr ""
 
-#: src/Admin/Settings/Page.php:209, src/Admin/Settings/Page.php:210
+#: src/Admin/Settings/Page.php:282, src/Admin/Settings/Page.php:283
 msgid "Analytics"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:218, src/Admin/Settings/Page.php:219, src/Admin/Settings/Page.php:253
+#: src/Admin/Settings/Page.php:291, src/Admin/Settings/Page.php:292, src/Admin/Settings/Page.php:326
 msgid "Plausible Analytics"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:286
+#: src/Admin/Settings/Page.php:359
 msgid "General"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:291
+#: src/Admin/Settings/Page.php:364
 msgid "Self Hosted"
 msgstr ""
 
-#: src/Admin/Settings/Page.php:361
+#: src/Admin/Settings/Page.php:434
 msgid "You don't have sufficient privileges to access the analytics dashboard. Please contact administrator of the website to grant you the access."
 msgstr ""

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -323,7 +323,7 @@ class Page extends API {
 		?>
 		<div class="plausible-analytics-header">
 			<div class="plausible-analytics-logo">
-				<img src="<?php echo PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/images/icon.png'; ?>" alt="<?php esc_html_e( 'Plausible Analytics', 'plausible-analytics' ); ?>"/>
+				<img src="<?php echo trailingslashit( PLAUSIBLE_ANALYTICS_PLUGIN_URL ) . 'assets/dist/images/icon.png'; ?>" alt="<?php esc_html_e( 'Plausible Analytics', 'plausible-analytics' ); ?>"/>
 			</div>
 			<div class="plausible-analytics-header-content">
 				<div class="plausible-analytics-title">

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -33,7 +33,8 @@ class Page extends API {
 		$self_hosted_domain = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : 'example.com';
 		$shared_link        = ! empty( $settings['shared_link'] ) ? $settings['shared_link'] : "https://plausible.io/share/{$domain}?auth=XXXXXXXXXXXX";
 		$excluded_pages     = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : '/imprint, /privacy-policy';
-		$custom_domain      = ! empty( $settings['custom_domain'] ) ? $settings['custom_domain'] : "analytics.{$domain}";
+		$script_path        = ! empty( $settings['script_path'] ) ? $settings['script_path'] : '';
+		$event_path         = ! empty( $settings['event_path'] ) ? $settings['event_path'] : '';
 
 		$this->fields = [
 			'general'     => [
@@ -58,31 +59,6 @@ class Page extends API {
 							'slug'  => 'domain_name',
 							'type'  => 'text',
 							'value' => $domain,
-						],
-					],
-				],
-				[
-					'label'  => esc_html__( 'Setup custom domain with Plausible Analytics', 'plausible-analytics' ),
-					'slug'   => 'is_custom_domain',
-					'type'   => 'group',
-					'desc'   => sprintf(
-						'<ol><li>%1$s <a href="%2$s" target="_blank">%3$s</a></li><li>%4$s %5$s %6$s %7$s %8$s</li></ol>',
-						esc_html__( 'Enable the custom domain functionality in your Plausible account.', 'plausible-analytics' ),
-						esc_url( 'https://docs.plausible.io/custom-domain/' ),
-						esc_html__( 'See how &raquo;', 'plausible-analytics' ),
-						esc_html__( 'Enable this setting and configure it to link with Plausible Analytics on your custom domain.', 'plausible-analytics' ),
-						esc_html__( 'For example,', 'plausible-analytics' ),
-						"<code>stats.$domain</code>",
-						esc_html__( 'or', 'plausible-analytics' ),
-						"<code>analytics.$domain</code>"
-					),
-					'toggle' => true,
-					'fields' => [
-						[
-							'label' => esc_html__( 'Custom Domain', 'plausible-analytics' ),
-							'slug'  => 'custom_domain',
-							'type'  => 'text',
-							'value' => $custom_domain,
 						],
 					],
 				],
@@ -236,6 +212,33 @@ class Page extends API {
 						],
 					],
 				],
+				[
+					'label'  => esc_html__( 'Run analytics script from a custom path', 'plausible-analytics' ),
+					'slug'   => 'is_custom_path',
+					'type'   => 'group',
+					'desc'   => sprintf(
+						'<p>%1$s <a href="%2$s" target="_blank">%3$s</a></p><p>%4$s</p>',
+						esc_html__( 'Use a proxy to run Plausible and hide your tracking from ad blockers.', 'plausible-analytics' ),
+						esc_url( 'https://plausible.io/docs/proxy/introduction' ),
+						esc_html__( 'See how &raquo;', 'plausible-analytics' ),
+						sprintf( esc_html__( 'Remove %1$s from your script URL and %2$s from your event API URL to get their paths.', 'plausible-analytics' ), '<code>script.js</code>', '<code>event</code>' )
+					),
+					'toggle' => false,
+					'fields' => [
+						[
+							'label' => esc_html__( 'Script Path', 'plausible-analytics' ),
+							'slug'  => 'script_path',
+							'type'  => 'text',
+							'value' => $script_path,
+						],
+						[
+							'label' => esc_html__( 'Event API Path', 'plausible-analytics' ),
+							'slug'  => 'event_path',
+							'type'  => 'text',
+							'value' => $event_path,
+						],
+					],
+				],
 			],
 			'self-hosted' => [
 				[
@@ -320,7 +323,7 @@ class Page extends API {
 		?>
 		<div class="plausible-analytics-header">
 			<div class="plausible-analytics-logo">
-				<img src="<?php echo PLAUSIBLE_ANALYTICS_PLUGIN_URL . '/assets/dist/images/icon.png'; ?>" alt="<?php esc_html_e( 'Plausible Analytics', 'plausible-analytics' ); ?>"/>
+				<img src="<?php echo PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/images/icon.png'; ?>" alt="<?php esc_html_e( 'Plausible Analytics', 'plausible-analytics' ); ?>"/>
 			</div>
 			<div class="plausible-analytics-header-content">
 				<div class="plausible-analytics-title">

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -61,6 +61,11 @@ class Actions {
 		if ( apply_filters( 'plausible_analytics_enable_404', true ) && is_404() ) {
 			wp_add_inline_script( 'plausible-analytics', 'plausible("404",{ props: { path: document.location.pathname } });' );
 		}
+
+		// Track search results.
+		if ( apply_filters( 'plausible_analytics_track_search', true ) && is_search() ) {
+			wp_add_inline_script( 'plausible-analytics', 'plausible("pageview", { u: "' . esc_attr( get_search_link() ) . '" })' );
+		}
 	}
 
 	/**

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -61,11 +61,6 @@ class Actions {
 		if ( apply_filters( 'plausible_analytics_enable_404', true ) && is_404() ) {
 			wp_add_inline_script( 'plausible-analytics', 'plausible("404",{ props: { path: document.location.pathname } });' );
 		}
-
-		// Track search results.
-		if ( apply_filters( 'plausible_analytics_track_search', true ) && is_search() ) {
-			wp_add_inline_script( 'plausible-analytics', 'plausible("pageview", { u: "' . esc_attr( get_search_link() ) . '" })' );
-		}
 	}
 
 	/**

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -49,11 +49,6 @@ class Helpers {
 			}
 		}
 
-		if ( is_search() ) {
-			// Add the manual scripts as we need it to track the search parameter.
-			$file_name .= '.manual';
-		}
-
 		return self::get_script_url_path() . $file_name . '.js';
 	}
 

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -49,6 +49,11 @@ class Helpers {
 			}
 		}
 
+		if ( is_search() ) {
+			// Add the manual scripts as we need it to track the search parameter.
+			$file_name .= '.manual';
+		}
+
 		return self::get_script_url_path() . $file_name . '.js';
 	}
 

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -20,10 +20,10 @@ class Helpers {
 	/**
 	 * Get Plain Domain.
 	 *
+	 * @return string
 	 * @since  1.0.0
 	 * @access public
 	 *
-	 * @return string
 	 */
 	public static function get_domain() {
 		$site_url = site_url();
@@ -34,16 +34,14 @@ class Helpers {
 	/**
 	 * Get Analytics URL.
 	 *
+	 * @return string
 	 * @since  1.0.0
 	 * @access public
 	 *
-	 * @return string
 	 */
 	public static function get_analytics_url() {
-		$settings       = self::get_settings();
-		$domain         = $settings['domain_name'];
-		$default_domain = 'plausible.io';
-		$file_name      = 'plausible';
+		$settings  = self::get_settings();
+		$file_name = 'script';
 
 		foreach ( [ 'outbound-links', 'file-downloads', 'compat', 'hash' ] as $extension ) {
 			if ( ! empty( $settings[ $extension ] ) && $settings[ $extension ][0] === '1' ) {
@@ -56,6 +54,25 @@ class Helpers {
 			$file_name .= '.manual';
 		}
 
+		return self::get_script_url_path() . $file_name . '.js';
+	}
+
+	/**
+	 * Determine the script's path.
+	 *
+	 * @return string
+	 */
+	private static function get_script_url_path() {
+		$settings = self::get_settings();
+
+		// Early return when there's a script path.
+		if ( ! empty( $settings['script_path'] ) && is_string( $settings['script_path'] ) ) {
+			return $settings['script_path'];
+		}
+
+		$domain         = $settings['domain_name'];
+		$default_domain = 'plausible.io';
+
 		// Triggered when self-hosted analytics is enabled.
 		if (
 			! empty( $settings['is_self_hosted_analytics'] ) &&
@@ -64,7 +81,7 @@ class Helpers {
 			$default_domain = $settings['self_hosted_domain'];
 		}
 
-		$url = "https://{$default_domain}/js/{$file_name}.js";
+		$path = "https://{$default_domain}/js/";
 
 		// Triggered when custom domain is enabled.
 		if (
@@ -72,10 +89,10 @@ class Helpers {
 			'true' === $settings['custom_domain']
 		) {
 			$custom_domain_prefix = $settings['custom_domain_prefix'];
-			$url                  = "https://{$custom_domain_prefix}.{$domain}/js/{$file_name}.js";
+			$path                 = "https://{$custom_domain_prefix}.{$domain}/js/";
 		}
 
-		return $url;
+		return $path;
 	}
 
 	/**
@@ -145,6 +162,10 @@ class Helpers {
 	public static function get_data_api_url() {
 		$settings = self::get_settings();
 		$url      = 'https://plausible.io/api/event';
+		// Early return when there's an event API path set.
+		if ( ! empty( $settings['event_path'] ) && is_string( $settings['event_path'] ) ) {
+			return trailingslashit( $settings['event_path'] ) . 'event';
+		}
 
 		// Triggered when self hosted analytics is enabled.
 		if (
@@ -171,10 +192,10 @@ class Helpers {
 	/**
 	 * Get Quick Actions.
 	 *
+	 * @return array
 	 * @since  1.3.0
 	 * @access public
 	 *
-	 * @return array
 	 */
 	public static function get_quick_actions() {
 		return [
@@ -196,10 +217,10 @@ class Helpers {
 	/**
 	 * Render Quick Actions
 	 *
+	 * @return string
 	 * @since  1.3.0
 	 * @access public
 	 *
-	 * @return string
 	 */
 	public static function render_quick_actions() {
 		ob_start();
@@ -239,10 +260,10 @@ class Helpers {
 	 *
 	 * @param string|array $var Sanitize the variable.
 	 *
+	 * @return string|array
 	 * @since  1.3.0
 	 * @access public
 	 *
-	 * @return string|array
 	 */
 	public static function clean( $var ) {
 		if ( is_array( $var ) ) {
@@ -255,10 +276,10 @@ class Helpers {
 	/**
 	 * Get user role for the logged-in user.
 	 *
+	 * @return string
 	 * @since  1.3.0
 	 * @access public
 	 *
-	 * @return string
 	 */
 	public static function get_user_role() {
 		global $current_user;

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -156,12 +156,12 @@ class Helpers {
 	 */
 	public static function get_data_api_url() {
 		$settings = self::get_settings();
-		$url      = 'https://plausible.io/api/event';
 		// Early return when there's an event API path set.
 		if ( ! empty( $settings['event_path'] ) && is_string( $settings['event_path'] ) ) {
 			return trailingslashit( $settings['event_path'] ) . 'event';
 		}
 
+		$url = 'https://plausible.io/api/event';
 		// Triggered when self hosted analytics is enabled.
 		if (
 			! empty( $settings['is_self_hosted_analytics'] ) &&

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -51,6 +51,11 @@ class Helpers {
 			}
 		}
 
+		if ( is_search() ) {
+			// Add the manual scripts as we need it to track the search parameter.
+			$file_name .= '.manual';
+		}
+
 		// Triggered when self-hosted analytics is enabled.
 		if (
 			! empty( $settings['is_self_hosted_analytics'] ) &&

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -20,10 +20,10 @@ class Helpers {
 	/**
 	 * Get Plain Domain.
 	 *
-	 * @return string
 	 * @since  1.0.0
 	 * @access public
 	 *
+	 * @return string
 	 */
 	public static function get_domain() {
 		$site_url = site_url();
@@ -34,10 +34,10 @@ class Helpers {
 	/**
 	 * Get Analytics URL.
 	 *
-	 * @return string
 	 * @since  1.0.0
 	 * @access public
 	 *
+	 * @return string
 	 */
 	public static function get_analytics_url() {
 		$settings  = self::get_settings();
@@ -187,10 +187,10 @@ class Helpers {
 	/**
 	 * Get Quick Actions.
 	 *
-	 * @return array
 	 * @since  1.3.0
 	 * @access public
 	 *
+	 * @return array
 	 */
 	public static function get_quick_actions() {
 		return [
@@ -212,10 +212,10 @@ class Helpers {
 	/**
 	 * Render Quick Actions
 	 *
-	 * @return string
 	 * @since  1.3.0
 	 * @access public
 	 *
+	 * @return string
 	 */
 	public static function render_quick_actions() {
 		ob_start();
@@ -255,10 +255,10 @@ class Helpers {
 	 *
 	 * @param string|array $var Sanitize the variable.
 	 *
-	 * @return string|array
 	 * @since  1.3.0
 	 * @access public
 	 *
+	 * @return string|array
 	 */
 	public static function clean( $var ) {
 		if ( is_array( $var ) ) {
@@ -271,10 +271,10 @@ class Helpers {
 	/**
 	 * Get user role for the logged-in user.
 	 *
-	 * @return string
 	 * @since  1.3.0
 	 * @access public
 	 *
+	 * @return string
 	 */
 	public static function get_user_role() {
 		global $current_user;


### PR DESCRIPTION
This adds tracking of search URLs, on sites with clean permalinks enabled they'd be tracked as `https://example.com/search/test/`.

See [my comment](https://github.com/plausible/wordpress/issues/47#issuecomment-1188951569) here though, I'm not so sure this is the right implementation.