### PR TITLE
Prevent frontend notice on non-singular pages

### DIFF
--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -90,7 +90,7 @@ class Actions {
 		];
 
 		// Add link to individual page stats.
-		if ( ! is_admin() ) {
+		if ( is_singular() ) {
 			global $post;
 			$args[] = [
 				'id'     => 'view-page-analytics',


### PR DESCRIPTION
Since this code uses `$post->post_name`, we should only run the code when `is_singular` is true.