### PR TITLE
Remove custom domain

### DIFF
--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -55,7 +55,7 @@ class Actions {
 	public function save_admin_settings() {
 		// Sanitize all the post data before using.
 		$post_data = Helpers::clean( $_POST );
-		
+
 		// Security: Roadblock to check for unauthorized access.
 		if (
 			'plausible_analytics_save_admin_settings' === $post_data['action'] &&
@@ -70,12 +70,11 @@ class Actions {
 			unset( $post_data['roadblock'] );
 
 			if (
-				! empty( $post_data['plausible_analytics_settings']['domain_name'] ) &&
-				! empty( $post_data['plausible_analytics_settings']['custom_domain'] )
+				! empty( $post_data['plausible_analytics_settings']['domain_name'] )
 			) {
 				// Update all the options to plausible settings.
 				update_option( 'plausible_analytics_settings', $post_data['plausible_analytics_settings'] );
-				
+
 				$status  = 'success';
 				$message = esc_html__( 'Settings saved successfully.', 'plausible-analytics' );
 			} else {
@@ -87,7 +86,7 @@ class Actions {
 			wp_send_json_success(
 				[
 					'message' => $message,
-					'status'  => $status
+					'status'  => $status,
 				]
 			);
 		}

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -85,7 +85,7 @@ class API {
 		<label for="<?php echo $field['slug']; ?>">
 			<?php echo esc_attr( $field['label'] ); ?>
 		</label>
-		<input id="<?php echo $field['slug']; ?>" <?php echo $field['placeholder'] ? 'placeholder="' . $field['placeholder'] . '"' : ''; ?> type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
+		<input id="<?php echo $field['slug']; ?>" <?php echo $field['placeholder'] ?? 'placeholder="' . $field['placeholder'] . '"'; ?> type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
 		<?php
 		return ob_get_clean();
 	}

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -85,7 +85,7 @@ class API {
 		<label for="<?php echo $field['slug']; ?>">
 			<?php echo esc_attr( $field['label'] ); ?>
 		</label>
-		<input id="<?php echo $field['slug']; ?>" type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
+		<input id="<?php echo $field['slug']; ?>" <?php echo $field['placeholder'] ? 'placeholder="' . $field['placeholder'] . '"' : ''; ?> type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
 		<?php
 		return ob_get_clean();
 	}

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -85,7 +85,7 @@ class API {
 		<label for="<?php echo $field['slug']; ?>">
 			<?php echo esc_attr( $field['label'] ); ?>
 		</label>
-		<input id="<?php echo $field['slug']; ?>" <?php echo $field['placeholder'] ?? 'placeholder="' . $field['placeholder'] . '"'; ?> type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
+		<input id="<?php echo $field['slug']; ?>" <?php isset( $field['placeholder'] ) ? 'placeholder="' . $field['placeholder'] . '"' : ''; ?> type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
 		<?php
 		return ob_get_clean();
 	}

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -28,17 +28,14 @@ class Page extends API {
 	 * @return void
 	 */
 	public function __construct() {
-		$settings            = Helpers::get_settings();
-		$domain              = ! empty( $settings['domain_name'] ) ? $settings['domain_name'] : Helpers::get_domain();
-		$self_hosted_domain  = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : 'example.com';
-		$shared_link         = ! empty( $settings['shared_link'] ) ? $settings['shared_link'] : "https://plausible.io/share/{$domain}?auth=XXXXXXXXXXXX";
-		$excluded_pages      = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : '/imprint, /privacy-policy';
-		$custom_domain       = ! empty( $settings['custom_domain'] ) ? $settings['custom_domain'] : "analytics.{$domain}";
-		$is_shared_link      = ! empty( $settings['is_shared_link'] ) ? (bool) $settings['is_shared_link'] : false;
-		$is_custom_domain    = ! empty( $settings['is_custom_domain'] ) ? (bool) $settings['is_custom_domain'] : false;
-		$is_exclude_pages    = ! empty( $settings['is_exclude_pages'] ) ? (bool) $settings['is_exclude_pages'] : false;
-		$is_selfhosted       = ! empty( $settings['is_self_hosted_plausible_analytics'] ) ? (bool) $settings['is_self_hosted_plausible_analytics'] : false;
-		$can_track_analytics = ! empty( $settings['can_role_track_analytics'] ) ? (bool) $settings['can_role_track_analytics'] : false;
+		$settings           = Helpers::get_settings();
+		$domain             = ! empty( $settings['domain_name'] ) ? $settings['domain_name'] : Helpers::get_domain();
+		$self_hosted_domain = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : 'example.com';
+		$shared_link        = ! empty( $settings['shared_link'] ) ? $settings['shared_link'] : '';
+		$excluded_pages     = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : '/imprint, /privacy-policy';
+		$is_shared_link     = ! empty( $settings['is_shared_link'] ) ? (bool) $settings['is_shared_link'] : false;
+		$is_exclude_pages   = ! empty( $settings['is_exclude_pages'] ) ? (bool) $settings['is_exclude_pages'] : false;
+		$is_selfhosted      = ! empty( $settings['is_self_hosted_plausible_analytics'] ) ? (bool) $settings['is_self_hosted_plausible_analytics'] : false;
 
 		$this->fields = [
 			'general'     => [
@@ -63,31 +60,6 @@ class Page extends API {
 							'slug'  => 'domain_name',
 							'type'  => 'text',
 							'value' => $domain,
-						],
-					],
-				],
-				[
-					'label'  => esc_html__( 'Setup custom domain with Plausible Analytics', 'plausible-analytics' ),
-					'slug'   => 'is_custom_domain',
-					'type'   => 'group',
-					'desc'   => sprintf(
-						'<ol><li>%1$s <a href="%2$s" target="_blank">%3$s</a></li><li>%4$s %5$s %6$s %7$s %8$s</li></ol>',
-						esc_html__( 'Enable the custom domain functionality in your Plausible account.', 'plausible-analytics' ),
-						esc_url( 'https://docs.plausible.io/custom-domain/' ),
-						esc_html__( 'See how &raquo;', 'plausible-analytics' ),
-						esc_html__( 'Enable this setting and configure it to link with Plausible Analytics on your custom domain.', 'plausible-analytics' ),
-						esc_html__( 'For example,', 'plausible-analytics' ),
-						"<code>stats.$domain</code>",
-						esc_html__( 'or', 'plausible-analytics' ),
-						"<code>analytics.$domain</code>"
-					),
-					'toggle' => $is_custom_domain,
-					'fields' => [
-						[
-							'label' => esc_html__( 'Custom Domain', 'plausible-analytics' ),
-							'slug'  => 'custom_domain',
-							'type'  => 'text',
-							'value' => $custom_domain,
 						],
 					],
 				],
@@ -154,10 +126,11 @@ class Page extends API {
 					'toggle' => $is_shared_link,
 					'fields' => [
 						[
-							'label' => esc_html__( 'Shared Link', 'plausible-analytics' ),
-							'slug'  => 'shared_link',
-							'type'  => 'text',
-							'value' => $shared_link,
+							'label'       => esc_html__( 'Shared Link', 'plausible-analytics' ),
+							'slug'        => 'shared_link',
+							'type'        => 'text',
+							'value'       => $shared_link,
+							'placeholder' => "https://plausible.io/share/{$domain}?auth=XXXXXXXXXXXX"
 						],
 					],
 				],

--- a/src/Admin/Upgrades.php
+++ b/src/Admin/Upgrades.php
@@ -54,7 +54,7 @@ class Upgrades {
 		}
 
 		// Upgrade to version 1.3.0.
-		if ( version_compare( $plausible_analytics_version, '1.3.0', '<=' ) ) {
+		if ( version_compare( $plausible_analytics_version, '1.3.0', '<' ) ) {
 			$this->upgrade_to_130();
 		}
 
@@ -72,7 +72,7 @@ class Upgrades {
 	public function upgrade_to_130() {
 		$old_settings = Helpers::get_settings();
 		$new_settings = $old_settings;
-		
+
 		$old_custom_domain_prefix     = ! empty( $old_settings['custom_domain_prefix'] ) ? $old_settings['custom_domain_prefix'] : '';
 		$old_embed_analytics          = ! empty( $old_settings['embed_analytics'] ) ? $old_settings['embed_analytics'] : '';
 		$old_is_self_hosted_analytics = ! empty( $old_settings['is_self_hosted_analytics'] ) ? $old_settings['is_self_hosted_analytics'] : '';
@@ -80,7 +80,7 @@ class Upgrades {
 		if ( is_bool( $old_settings['custom_domain'] ) || 'true' === $old_settings['custom_domain'] ) {
 			$new_settings['is_custom_domain'] = $old_settings['custom_domain'];
 		}
-		
+
 		$new_settings['custom_domain']  = "{$old_custom_domain_prefix}.{$old_settings['domain_name']}";
 		$new_settings['is_shared_link'] = $old_embed_analytics;
 
@@ -105,4 +105,3 @@ class Upgrades {
 		update_option( 'plausible_analytics_version', PLAUSIBLE_ANALYTICS_VERSION );
 	}
 }
-

--- a/src/Admin/Upgrades.php
+++ b/src/Admin/Upgrades.php
@@ -53,12 +53,47 @@ class Upgrades {
 			$plausible_analytics_version = '1.0.0';
 		}
 
+		if ( version_compare( $plausible_analytics_version, '1.2.5', '<' ) ) {
+			$this->upgrade_to_125();
+		}
+
 		// Upgrade to version 1.3.0.
 		if ( version_compare( $plausible_analytics_version, '1.3.0', '<' ) ) {
 			$this->upgrade_to_130();
 		}
 
 		// Add required upgrade routines for future versions here.
+	}
+
+	/**
+	 * Upgrade routine for 1.2.5
+	 *
+	 * Cleans Custom Domain related options from database, as it was removed in this version.
+	 *
+	 * @since  1.2.5
+	 * @access public
+	 *
+	 * @return void
+	 */
+	public function upgrade_to_125() {
+		$old_settings = Helpers::get_settings();
+		$new_settings = $old_settings;
+
+		if ( isset( $old_settings['custom_domain_prefix'] ) ) {
+			unset( $new_settings['custom_domain_prefix'] );
+		}
+
+		if ( isset( $old_settings['custom_domain'] ) ) {
+			unset( $new_settings['custom_domain'] );
+		}
+
+		if ( isset( $old_settings['is_custom_domain'] ) ) {
+			unset( $new_settings['is_custom_domain'] );
+		}
+
+		update_option( 'plausible_analytics_settings', $new_settings );
+
+		update_option( 'plausible_analytics_version', PLAUSIBLE_ANALYTICS_VERSION );
 	}
 
 	/**
@@ -73,15 +108,9 @@ class Upgrades {
 		$old_settings = Helpers::get_settings();
 		$new_settings = $old_settings;
 
-		$old_custom_domain_prefix     = ! empty( $old_settings['custom_domain_prefix'] ) ? $old_settings['custom_domain_prefix'] : '';
 		$old_embed_analytics          = ! empty( $old_settings['embed_analytics'] ) ? $old_settings['embed_analytics'] : '';
 		$old_is_self_hosted_analytics = ! empty( $old_settings['is_self_hosted_analytics'] ) ? $old_settings['is_self_hosted_analytics'] : '';
 
-		if ( is_bool( $old_settings['custom_domain'] ) || 'true' === $old_settings['custom_domain'] ) {
-			$new_settings['is_custom_domain'] = $old_settings['custom_domain'];
-		}
-
-		$new_settings['custom_domain']  = "{$old_custom_domain_prefix}.{$old_settings['domain_name']}";
 		$new_settings['is_shared_link'] = $old_embed_analytics;
 
 		if (

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -61,15 +61,6 @@ class Helpers {
 
 		$url = "https://{$default_domain}/js/{$file_name}.js";
 
-		// Triggered when custom domain is enabled.
-		if (
-			! empty( $settings['custom_domain'] ) &&
-			'true' === $settings['custom_domain']
-		) {
-			$custom_domain_prefix = $settings['custom_domain_prefix'];
-			$url                  = "https://{$custom_domain_prefix}.{$domain}/js/{$file_name}.js";
-		}
-
 		return esc_url( $url );
 	}
 
@@ -140,16 +131,6 @@ class Helpers {
 		) {
 			$default_domain = $settings['self_hosted_domain'];
 			$url            = "https://{$default_domain}/api/event";
-		}
-
-		// Triggered when custom domain is enabled.
-		if (
-			! empty( $settings['custom_domain'] ) &&
-			'true' === $settings['custom_domain']
-		) {
-			$domain               = $settings['domain_name'];
-			$custom_domain_prefix = $settings['custom_domain_prefix'];
-			$url                  = "https://{$custom_domain_prefix}.{$domain}/api/event";
 		}
 
 		return esc_url( $url );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -91,7 +91,6 @@ final class Plugin {
 			$domain_name      = Helpers::get_domain();
 			$default_settings = [
 				'domain_name'     => $domain_name,
-				'custom_domain'   => "analytics.{$domain_name}",
 				'track_analytics' => [],
 			];
 


### PR DESCRIPTION
This PR removes all code related to the Custom Domain option. It includes a DB cleanup script to remove DB entries related to the Custom Domain option, as well.

It also includes a few fixes, related to other issues, I came across along the way:
- I added support for the `placeholder` attribute to `text` inputs, because the example `auth` key was displayed as a `value`. When saved to the DB this would throw CORS related errors when trying to View Analytics.
- The DB upgrade script would run on each pageload, due to the _less than or equal to_ operator. Changed it to _less than_.