### PR TITLE
Added: compatibility fix for WP Rocket.

### DIFF
--- a/src/Includes/Compatibility.php
+++ b/src/Includes/Compatibility.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Plausible Analytics | Filters.
+ *
+ * @since      1.2.5
+ *
+ * @package    WordPress
+ * @subpackage Plausible Analytics
+ */
+
+namespace Plausible\Analytics\WP\Includes;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Compatibility {
+	/**
+	 * A list of filters and actions to prevent our script from being manipulated by other plugins, known to cause issues.
+	 *
+	 * Our script is already <1KB, so there's no need to minify, combine or optimize it in any other way.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		if ( defined( 'WP_ROCKET_VERSION' ) ) {
+			add_filter( 'rocket_excluded_inline_js_content', [ $this, 'exclude_plausible_inline_js' ] );
+			add_filter( 'rocket_exclude_js', [ $this, 'exclude_plausible_js' ] );
+			add_filter( 'rocket_minify_excluded_external_js', [ $this, 'exclude_plausible_js' ] );
+		}
+	}
+
+	/**
+	 * Dear WP Rocket, don't minify/combine our inline JS, please.
+	 *
+	 * @filter rocket_excluded_inline_js_content
+	 *
+	 * @param array $inline_js
+	 * @since 1.2.5
+	 *
+	 * @return array
+	 */
+	public function exclude_plausible_inline_js( $inline_js ) {
+		if ( ! isset( $inline_js['plausible'] ) ) {
+			$inline_js['plausible'] = 'window.plausible';
+		}
+
+		return $inline_js;
+	}
+
+	/**
+	 * Dear WP Rocket, don't minify/combine our external JS, please.
+	 *
+	 * @filter rocket_exclude_js
+	 * @filter rocket_minify_excluded_external_js
+	 *
+	 * @param array $excluded_js
+	 * @since 1.2.5
+	 *
+	 * @return array
+	 */
+	public function exclude_plausible_js( $excluded_js ) {
+		$excluded_js[] = Helpers::get_analytics_url();
+
+		return $excluded_js;
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,8 +30,8 @@ final class Plugin {
 		register_activation_hook( PLAUSIBLE_ANALYTICS_PLUGIN_FILE, [ $this, 'activate' ] );
 		register_deactivation_hook( PLAUSIBLE_ANALYTICS_PLUGIN_FILE, [ $this, 'deactivate' ] );
 
-		// Register services used throughout the plugin.
-		add_action( 'plugins_loaded', [ $this, 'register_services' ] );
+		// Register services used throughout the plugin. (WP Rocket runs at priority 10)
+		add_action( 'plugins_loaded', [ $this, 'register_services' ], 9 );
 
 		// Load text domain.
 		add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
@@ -54,6 +54,7 @@ final class Plugin {
 		}
 
 		new Includes\Actions();
+		new Includes\Compatibility();
 		new Includes\Filters();
 	}
 


### PR DESCRIPTION
Introduced the Compatibility class, which now automatically adds our JS to the exclude lists of WP Rocket, if the plugin is enabled.