### PR TITLE
Fixed: Self-hosted Domain name can't be saved

### DIFF
--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -54,7 +54,8 @@ class Actions {
 	 */
 	public function save_admin_settings() {
 		// Sanitize all the post data before using.
-		$post_data = Helpers::clean( $_POST );
+		$post_data        = Helpers::clean( $_POST );
+		$current_settings = Helpers::get_settings();
 
 		// Security: Roadblock to check for unauthorized access.
 		if (
@@ -65,15 +66,13 @@ class Actions {
 				wp_verify_nonce( $post_data['roadblock'], 'plausible-analytics-settings-roadblock' )
 			)
 		) {
-			// Unset unnecessary posted data to store into database.
-			unset( $post_data['action'] );
-			unset( $post_data['roadblock'] );
-
 			if (
 				! empty( $post_data['plausible_analytics_settings']['domain_name'] )
-			) {
+				|| isset( $post_data['plausible_analytics_settings']['self_hosted_domain'] ) ) {
+				$current_settings = array_replace( $current_settings, $post_data['plausible_analytics_settings'] );
+
 				// Update all the options to plausible settings.
-				update_option( 'plausible_analytics_settings', $post_data['plausible_analytics_settings'] );
+				update_option( 'plausible_analytics_settings', $current_settings );
 
 				$status  = 'success';
 				$message = esc_html__( 'Settings saved successfully.', 'plausible-analytics' );

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -155,9 +155,7 @@ class API {
 		$slug     = ! empty( $settings[ $field['slug'] ] ) ? $settings[ $field['slug'] ] : '';
 		?>
 		<span class="plausible-checkbox-list">
-			<input
-				id="<?php echo $field['slug']; ?>"
-				type="checkbox"
+			<input id="<?php echo $field['slug']; ?>" type="checkbox"
 				name="plausible_analytics_settings[<?php echo esc_attr( $field['slug'] ); ?>][]"
 				value="<?php echo esc_html( $value ); ?>"
 				<?php
@@ -168,6 +166,8 @@ class API {
 				}
 				?>
 			/>
+			<?php // This trick'll make our option always show up in $_POST. Even when unchecked. ?>
+			<input id="<?php echo $field['slug']; ?>" type="hidden" name="plausible_analytics_settings[<?php echo esc_attr( $field['slug'] ); ?>][]" value="0" />
 			<label for="<?php echo $field['slug']; ?>"><?php echo $field['label']; ?></label>
 			<?php if ( ! empty( $field['docs'] ) ) { ?>
 				- <a target="_blank" href="<?php echo $field['docs']; ?>"><?php echo $field['docs_label']; ?></a>

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -30,7 +30,7 @@ class Page extends API {
 	public function __construct() {
 		$settings           = Helpers::get_settings();
 		$domain             = ! empty( $settings['domain_name'] ) ? $settings['domain_name'] : Helpers::get_domain();
-		$self_hosted_domain = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : 'example.com';
+		$self_hosted_domain = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : '';
 		$shared_link        = ! empty( $settings['shared_link'] ) ? $settings['shared_link'] : '';
 		$excluded_pages     = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : '';
 		$is_shared_link     = ! empty( $settings['is_shared_link'] ) ? (bool) $settings['is_shared_link'] : false;
@@ -74,41 +74,41 @@ class Page extends API {
 							'label'      => esc_html__( 'Outbound links', 'plausible-analytics' ),
 							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-external-link-clicks',
 							'docs_label' => esc_html__( 'Additional action required', 'plausible-analytics' ),
-							'slug'       => 'outbound-links',
+							'slug'       => 'enhanced_measurements',
 							'type'       => 'checkbox',
-							'value'      => '1',
+							'value'      => 'outbound-links',
 						],
 						'file-downloads' => [
 							'label'      => esc_html__( 'File downloads', 'plausible-analytics' ),
 							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-file-downloads',
 							'docs_label' => esc_html__( 'Additional action required', 'plausible-analytics' ),
-							'slug'       => 'file-downloads',
+							'slug'       => 'enhanced_measurements',
 							'type'       => 'checkbox',
-							'value'      => '1',
+							'value'      => 'file-downloads',
 						],
 						'tagged-events'  => [
 							'label'      => esc_html__( 'Custom events', 'plausible-analytics' ),
 							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-setup-custom-events-to-track-goal-conversions',
 							'docs_label' => esc_html__( 'Additional action required', 'plausible-analytics' ),
-							'slug'       => 'tagged-events',
+							'slug'       => 'enhanced_measurements',
 							'type'       => 'checkbox',
-							'value'      => '1',
+							'value'      => 'tagged-events',
 						],
 						'hash'           => [
 							'label'      => esc_html__( 'Hash-based routing', 'plausible-analytics' ),
 							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-enable-hash-based-url-tracking',
 							'docs_label' => esc_html__( 'Documentation', 'plausible-analytics' ),
-							'slug'       => 'hash',
+							'slug'       => 'enhanced_measurements',
 							'type'       => 'checkbox',
-							'value'      => '1',
+							'value'      => 'hash',
 						],
 						'compat'         => [
 							'label'      => esc_html__( 'IE compatibility', 'plausible-analytics' ),
 							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-visitors-who-use-internet-explorer',
 							'docs_label' => esc_html__( 'Documentation', 'plausible-analytics' ),
-							'slug'       => 'compat',
+							'slug'       => 'enhanced_measurements',
 							'type'       => 'checkbox',
-							'value'      => '1',
+							'value'      => 'compat',
 						],
 					],
 				],
@@ -160,32 +160,32 @@ class Page extends API {
 				],
 				[
 					'label'  => esc_html__( 'Track analytics for user roles', 'plausible-analytics' ),
-					'slug'   => 'can_role_track_analytics',
+					'slug'   => 'can_role_tracked_user_roles',
 					'type'   => 'group',
 					'desc'   => esc_html__( 'By default, we won\'t be tracking visits of any of the user roles listed above. If you want to track analytics for specific user roles then please check the specific user role setting.', 'plausible-analytics' ),
 					'toggle' => false,
 					'fields' => [
 						'administrator' => [
 							'label' => esc_html__( 'Administrator', 'plausible-analytics' ),
-							'slug'  => 'track_analytics',
+							'slug'  => 'tracked_user_roles',
 							'type'  => 'checkbox',
 							'value' => 'administrator',
 						],
 						'editor'        => [
 							'label' => esc_html__( 'Editor', 'plausible-analytics' ),
-							'slug'  => 'track_analytics',
+							'slug'  => 'tracked_user_roles',
 							'type'  => 'checkbox',
 							'value' => 'editor',
 						],
 						'author'        => [
 							'label' => esc_html__( 'Author', 'plausible-analytics' ),
-							'slug'  => 'track_analytics',
+							'slug'  => 'tracked_user_roles',
 							'type'  => 'checkbox',
 							'value' => 'author',
 						],
 						'contributor'   => [
 							'label' => esc_html__( 'Contributor', 'plausible-analytics' ),
-							'slug'  => 'track_analytics',
+							'slug'  => 'tracked_user_roles',
 							'type'  => 'checkbox',
 							'value' => 'contributor',
 						],
@@ -200,19 +200,19 @@ class Page extends API {
 					'fields' => [
 						'editor'      => [
 							'label' => esc_html__( 'Editor', 'plausible-analytics' ),
-							'slug'  => 'access_to_user_roles',
+							'slug'  => 'expand_dashboard_access',
 							'type'  => 'checkbox',
 							'value' => 'editor',
 						],
 						'author'      => [
 							'label' => esc_html__( 'Author', 'plausible-analytics' ),
-							'slug'  => 'access_to_user_roles',
+							'slug'  => 'expand_dashboard_access',
 							'type'  => 'checkbox',
 							'value' => 'author',
 						],
 						'contributor' => [
 							'label' => esc_html__( 'Contributor', 'plausible-analytics' ),
-							'slug'  => 'access_to_user_roles',
+							'slug'  => 'expand_dashboard_access',
 							'type'  => 'checkbox',
 							'value' => 'contributor',
 						],
@@ -233,18 +233,19 @@ class Page extends API {
 					'toggle' => $is_selfhosted,
 					'fields' => [
 						[
-							'label' => esc_html__( 'Domain Name', 'plausible-analytics' ),
-							'slug'  => 'self_hosted_domain',
-							'type'  => 'text',
-							'value' => $self_hosted_domain,
+							'label'       => esc_html__( 'Domain Name', 'plausible-analytics' ),
+							'slug'        => 'self_hosted_domain',
+							'type'        => 'text',
+							'value'       => $self_hosted_domain,
+							'placeholder' => 'e.g. ' . Helpers::get_domain(),
 						],
 					],
 				],
 			],
 		];
 
-				add_action( 'admin_menu', [ $this, 'register_menu' ] );
-				add_action( 'in_admin_header', [ $this, 'render_page_header' ] );
+		add_action( 'admin_menu', [ $this, 'register_menu' ] );
+		add_action( 'in_admin_header', [ $this, 'render_page_header' ] );
 	}
 
 	/**
@@ -395,7 +396,7 @@ class Page extends API {
 
 		if ( $can_access_analytics_page ) {
 			$has_access             = false;
-			$user_roles_have_access = ! empty( $settings['access_to_user_roles'] ) ? $settings['access_to_user_roles'] : [ 'administrator' ];
+			$user_roles_have_access = ! empty( $settings['expand_dashboard_access'] ) ? $settings['expand_dashboard_access'] : [ 'administrator' ];
 
 			foreach ( $current_user->roles as $role ) {
 				if ( in_array( $role, $user_roles_have_access, true ) ) {

--- a/src/Admin/Upgrades.php
+++ b/src/Admin/Upgrades.php
@@ -92,7 +92,12 @@ class Upgrades {
 		}
 
 		// Enable Outbound links by default.
-		$new_settings['outbound-links'][0] = '1';
+		$new_settings['enhanced_measurements'] = [ 'outbound-links' ];
+
+		if ( ! empty( $old_settings['track_administrator'] )
+			&& $old_settings['track_administrator'] ) {
+			$new_settings['tracked_user_roles'] = [ 'administrator' ];
+		}
 
 		update_option( 'plausible_analytics_settings', $new_settings );
 
@@ -111,21 +116,8 @@ class Upgrades {
 		$old_settings = Helpers::get_settings();
 		$new_settings = $old_settings;
 
-		$old_embed_analytics          = ! empty( $old_settings['embed_analytics'] ) ? $old_settings['embed_analytics'] : '';
-		$old_is_self_hosted_analytics = ! empty( $old_settings['is_self_hosted_analytics'] ) ? $old_settings['is_self_hosted_analytics'] : '';
-
+		$old_embed_analytics            = ! empty( $old_settings['embed_analytics'] ) ? $old_settings['embed_analytics'] : '';
 		$new_settings['is_shared_link'] = $old_embed_analytics;
-
-		if (
-			! empty( $old_settings['track_administrator'] ) &&
-			$old_settings['track_administrator']
-		) {
-			$new_settings['can_role_track_analytics'] = true;
-			$new_settings['track_analytics']          = [ 'administrator' ];
-		}
-
-		// For self hosted plausible analytics.
-		$new_settings['is_self_hosted_plausible_analytics'] = $old_is_self_hosted_analytics;
 
 		// Update the new settings.
 		update_option( 'plausible_analytics_settings', $new_settings );

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -45,14 +45,14 @@ class Actions {
 		$user_role = Helpers::get_user_role();
 
 		/**
-		 * Bail if track_analytics is empty (which means no roles should be tracked) or,
+		 * Bail if tracked_user_roles is empty (which means no roles should be tracked) or,
 		 * if current role should not be tracked.
 		 */
 		if (
 			( ! empty( $user_role )
-				&& ! isset( $settings['track_analytics'] ) )
+				&& ! isset( $settings['tracked_user_roles'] ) )
 			|| ( ! empty( $user_role )
-				&& ! in_array( $user_role, $settings['track_analytics'], true ) )
+				&& ! in_array( $user_role, $settings['tracked_user_roles'], true ) )
 			) {
 			return;
 		}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -91,8 +91,8 @@ final class Plugin {
 		if ( ! $is_default_settings_saved ) {
 			$domain_name      = Helpers::get_domain();
 			$default_settings = [
-				'domain_name'     => $domain_name,
-				'track_analytics' => [],
+				'domain_name'        => $domain_name,
+				'tracked_user_roles' => [],
 			];
 
 			update_option( 'plausible_analytics_settings', $default_settings );


### PR DESCRIPTION
This PR takes care of a few other things, too:

Improved: Re-factor Enhanced Measurements DB storage
Fixed: Self-hosted Domain didn't work.
Improved: renamed track_analytics > to tracked_user_roles
Improved: renamed access_to_user_roles > expand_dashboard_access