### PR TITLE
1.2.6

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Define plugin version in SemVer format.
 if ( ! defined( 'PLAUSIBLE_ANALYTICS_VERSION' ) ) {
-	define( 'PLAUSIBLE_ANALYTICS_VERSION', '1.2.5' );
+	define( 'PLAUSIBLE_ANALYTICS_VERSION', '1.2.6' );
 }
 
 // Define plugin root File.

--- a/plausible-analytics.php
+++ b/plausible-analytics.php
@@ -5,7 +5,7 @@
  * Description: Simple and privacy-friendly alternative to Google Analytics.
  * Author: PlausibleHQ
  * Author URI: https://plausible.io
- * Version: 1.2.5
+ * Version: 1.2.6
  * Text Domain: plausible-analytics
  * Domain Path: /languages
  *

--- a/readme.txt
+++ b/readme.txt
@@ -161,7 +161,7 @@ Please make sure you make a backup of your database before updating any version 
 - Don't allow people to enable stats dashboard without pasting their shared link [#34](https://github.com/plausible/wordpress/issues/34)
 - Added: compatibility for WP Rocket
 - Removed: Custom Domains options
-- Added: Enhanced Measurements, i.e. Outbound Links, File Downloads, Custom Events, Hash-based Routing and IE compatibility.
+- Added: Enhanced Measurements, i.e. Outbound Links, File Downloads, Custom Events, Hash-based Routing and IE compatibility. (thanks, @jdevalk!)
 - Several code optimizations.
 
 Props @sadmansh and @davidehuey for the contributions.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: analytics, google analytics, web analytics, stats, privacy, privacy friend
 Requires at least: 4.8
 Tested up to: 6.2
 Requires PHP: 5.6
-Stable tag: 1.2.5
+Stable tag: 1.2.6
 License: Massachusetts Institute of Technology (MIT) license
 License URI: https://opensource.org/licenses/MIT
 
@@ -153,6 +153,9 @@ Contact us: https://plausible.io/contact
 Please make sure you make a backup of your database before updating any version to ensure that none of your data is lost.
 
 == Changelog ==
+
+= 1.2.6 =
+- Added migration script to remove "example.com" default from DB for Self Hosted Domain option.
 
 = 1.2.5 =
 - 40-45% reduction in JS code

--- a/src/Admin/Upgrades.php
+++ b/src/Admin/Upgrades.php
@@ -57,12 +57,37 @@ class Upgrades {
 			$this->upgrade_to_125();
 		}
 
+		if ( version_compare( $plausible_analytics_version, '1.2.6', '<' ) ) {
+			$this->upgrade_to_126();
+		}
+
 		// Upgrade to version 1.3.0.
 		// if ( version_compare( $plausible_analytics_version, '1.3.0', '<' ) ) {
 		// 	$this->upgrade_to_130();
 		// }
 
 		// Add required upgrade routines for future versions here.
+	}
+
+	/**
+	 * Get rid of the previous "example.com" default for self_hosted_domain.
+	 *
+	 * @since 1.2.6
+	 *
+	 * @return void
+	 */
+	public function upgrade_to_126() {
+		$old_settings = Helpers::get_settings();
+		$new_settings = $old_settings;
+
+		if ( ! empty( $old_settings['self_hosted_domain'] )
+			&& strpos( $old_settings['self_hosted_domain'], 'example.com' ) !== false ) {
+				$new_settings['self_hosted_domain'] = '';
+		}
+
+		update_option( 'plausible_analytics_settings', $new_settings );
+
+		update_option( 'plausible_analytics_version', '1.2.6' );
 	}
 
 	/**


### PR DESCRIPTION
A quick patch release to provide a migration script for those that still have "example.com" stored in their database for the `self_hosted_domain` option, which was the default prior to 1.2.5.