### PR TITLE
Added: Disable Admin Menu option

### DIFF
--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -218,6 +218,22 @@ class Page extends API {
 						],
 					],
 				],
+				[
+					'label'         => esc_html__( 'Disable menu in toolbar', 'plausible-analytics' ),
+					'slug'          => 'disable_toolbar_menu',
+					'type'          => 'group',
+					'desc'          => esc_html__( 'Check this option if you don\'t want the Plausible Analytics menu item to be added to the toolbar at the top of the screen.', 'plausible-analytics' ),
+					'toggle'        => false,
+					'add_sub_array' => false,
+					'fields'        => [
+						'disable_toolbar_menu' => [
+							'label' => esc_html__( 'Disable toolbar menu', 'plausible-analytics' ),
+							'slug'  => 'disable_toolbar_menu',
+							'type'  => 'checkbox',
+							'value' => '1',
+						],
+					],
+				],
 			],
 			'self-hosted' => [
 				[

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -78,6 +78,12 @@ class Actions {
 	 * @access public
 	 */
 	public function admin_bar_node( $admin_bar ) {
+		$disable = ! empty( Helpers::get_settings()['disable_toolbar_menu'][0] );
+
+		if ( $disable ) {
+			return;
+		}
+
 		// Add main admin bar node.
 		$args = [
 			'id'    => 'plausible-admin-bar',

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -119,6 +119,7 @@ class Helpers {
 			'excluded_pages'          => '',
 			'tracked_user_roles'      => [],
 			'expand_dashboard_access' => [],
+			'disable_toolbar_menu'    => '',
 			'self_hosted_domain'      => '',
 		];
 


### PR DESCRIPTION
This PR takes care of https://github.com/plausible/wordpress/issues/113

