### PR TITLE
Added: allow self_hosted_domain to be defined using a constant.

### DIFF
--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -30,7 +30,7 @@ class Page extends API {
 	public function __construct() {
 		$settings           = Helpers::get_settings();
 		$domain             = ! empty( $settings['domain_name'] ) ? $settings['domain_name'] : Helpers::get_domain();
-		$self_hosted_domain = ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : '';
+		$self_hosted_domain = defined( 'PLAUSIBLE_SELF_HOSTED_DOMAIN' ) ? PLAUSIBLE_SELF_HOSTED_DOMAIN : ( ! empty( $settings['self_hosted_domain'] ) ? $settings['self_hosted_domain'] : '' );
 		$shared_link        = ! empty( $settings['shared_link'] ) ? $settings['shared_link'] : '';
 		$excluded_pages     = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : '';
 		$is_shared_link     = ! empty( $settings['is_shared_link'] ) ? (bool) $settings['is_shared_link'] : false;

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -42,6 +42,7 @@ class Helpers {
 	public static function get_analytics_url() {
 		$settings       = self::get_settings();
 		$default_domain = 'plausible.io';
+		$domain         = $default_domain;
 		$file_name      = 'plausible';
 
 		foreach ( [ 'outbound-links', 'file-downloads', 'tagged-events', 'compat', 'hash' ] as $extension ) {
@@ -55,14 +56,21 @@ class Helpers {
 			$file_name .= '.' . 'exclusions';
 		}
 
+		// Allows for hard-coding the self hosted domain.
+		if ( defined( 'PLAUSIBLE_SELF_HOSTED_DOMAIN' ) ) {
+			// phpcs:ignore
+			$domain = PLAUSIBLE_SELF_HOSTED_DOMAIN;
+		}
+
 		// Triggered when self-hosted analytics is enabled.
 		if (
 			! empty( $settings['self_hosted_domain'] )
+			&& $domain === $default_domain
 		) {
-			$default_domain = $settings['self_hosted_domain'];
+			$domain = $settings['self_hosted_domain'];
 		}
 
-		$url = "https://{$default_domain}/js/{$file_name}.js";
+		$url = "https://{$domain}/js/{$file_name}.js";
 
 		return esc_url( $url );
 	}


### PR DESCRIPTION
This takes care of PR https://github.com/plausible/wordpress/issues/78

This allows a constant, `PLAUSIBLE_SELF_HOSTED_DOMAIN` to be used to define the `self_hosted_domain`, as follows:

`define('PLAUSIBLE_SELF_HOSTED_DOMAIN', 'yourdomain.com);`

@metmarkosaric This should probably be mentioned somewhere in the documentation. 