### PR TITLE
Add search result tracking with an event

### DIFF
--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -71,7 +71,7 @@ class Actions {
 		if ( apply_filters( 'plausible_analytics_track_search', true ) && is_search() ) {
 			$search_url = str_replace( '%search%', '', get_site_url( null, $GLOBALS['wp_rewrite']->get_search_permastruct() ) );
 			$data = 'plausible("pageview", { u: "' . esc_attr( $search_url ) . '" });' .
-					'plausible( \'Search\', {props: {keyword: \'' . get_search_query() . '\', resultCount: ' . $GLOBALS['wp_query']->found_posts . '}});';
+					'plausible( \'Search\', {props: {keyword: \'' . get_search_query() . '\', resultCount: ' . intval( $GLOBALS['wp_query']->found_posts ) . '}});';
 			wp_add_inline_script( 'plausible-analytics', $data );
 		}
 	}

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -66,6 +66,14 @@ class Actions {
 		if ( apply_filters( 'plausible_analytics_enable_404', true ) && is_404() ) {
 			wp_add_inline_script( 'plausible-analytics', 'plausible("404",{ props: { path: document.location.pathname } });' );
 		}
+
+		// Track search results. Tracks a search event with the search term and the number of results, and a pageview with the site's search URL.
+		if ( apply_filters( 'plausible_analytics_track_search', true ) && is_search() ) {
+			$search_url = str_replace( '%search%', '', get_site_url( null, $GLOBALS['wp_rewrite']->get_search_permastruct() ) );
+			$data = 'plausible("pageview", { u: "' . esc_attr( $search_url ) . '" });' .
+					'plausible( \'Search\', {props: {keyword: \'' . get_search_query() . '\', resultCount: ' . $GLOBALS['wp_query']->found_posts . '}});';
+			wp_add_inline_script( 'plausible-analytics', $data );
+		}
 	}
 
 	/**

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -70,6 +70,11 @@ class Helpers {
 			$domain = $settings['self_hosted_domain'];
 		}
 
+		if ( is_search() ) {
+			// Add the manual scripts as we need it to track the search parameter.
+			$file_name .= '.manual';
+		}
+
 		$url = "https://{$domain}/js/{$file_name}.js";
 
 		return esc_url( $url );


### PR DESCRIPTION
Relatively simple method to track searches, using a custom `Search` event. To make this work, you'd have to setup the `Search` event as a Goal in the interface. This method will record a pageview to `https://example.com/search/` for every search action, instead of logging all those separate URLs, so the only way to find the keywords is within the events.

Fixes #47 