### PR TITLE
Proxy fixes

### DIFF
--- a/assets/src/css/admin/general.scss
+++ b/assets/src/css/admin/general.scss
@@ -14,8 +14,12 @@
 	}
 
 	.plausible-checkbox-list {
-		margin: 3px 0;
+		margin: .5em 1em .5em 0;
 		display: inline-block;
+	}
+
+	.plausible-hook {
+		padding: 1em 0 0 2em;
 	}
 
 	.plausible-analytics-content {
@@ -26,6 +30,12 @@
 		background-color: #fff;
 		margin-bottom: 20px;
 		padding: 15px;
+
+		&.enhanced-measurements {
+			.plausible-checkbox-list {
+				display: block;
+			}
+		}
 
 		label {
 			font-weight: 700;

--- a/assets/src/css/admin/trigger.scss
+++ b/assets/src/css/admin/trigger.scss
@@ -36,6 +36,19 @@
 		cursor: pointer;
 		color: $white-color;
 	}
+
+	&:disabled {
+		background-color: grey;
+
+		&:hover {
+			cursor: not-allowed;
+		}
+
+		&:active {
+			color: $white-color;
+			background-color: grey;
+		}
+	}
 }
 
 .plausible-analytics-save-btn {

--- a/assets/src/js/admin/main.js
+++ b/assets/src/js/admin/main.js
@@ -1,20 +1,31 @@
-document.addEventListener('DOMContentLoaded', () => {
-	const formElement = document.getElementById('plausible-analytics-settings-form');
+document.addEventListener( 'DOMContentLoaded', () => {
+	document.addEventListener( 'click', ( e ) => {
+		const dismissButton = e.target.closest( '.notice-dismiss' );
 
-	// Bailout, if `formElement` doesn't exist.
-	if (null === formElement) {
-		return;
-	}
+		if ( dismissButton ) {
+			const form = new FormData();
+	
+			form.append( 'action', 'plausible_analytics_notice_dismissed' );
+	
+			fetch(
+				ajaxurl,
+				{
+					method: 'POST',
+					body: form,
+				}
+			);
+		}
+	} );
 
-	const testProxy = document.getElementById('plausible-analytics-test-proxy');
+	const testProxy = document.getElementById( 'plausible-analytics-test-proxy' );
 
-	testProxy.addEventListener('click', (e) => {
+	testProxy.addEventListener( 'click', ( e ) => {
 		e.preventDefault();
 
 		const form = new FormData();
-		const span = document.getElementById('plausible-analytics-notice-test-proxy');
+		const span = document.getElementById( 'plausible-analytics-notice-test-proxy' );
 
-		form.append('action', 'plausible_analytics_test_proxy');
+		form.append( 'action', 'plausible_analytics_test_proxy' );
 
 		fetch(
 			ajaxurl,
@@ -22,27 +33,34 @@ document.addEventListener('DOMContentLoaded', () => {
 				method: 'POST',
 				body: form,
 			}
-		).then(response => {
+		).then( response => {
 			span.innerHTML = '<span class="plausible-analytics-loading spinner is-active"></span>';
 
 			return response.json();
-		}).then(response => {
+		} ).then( response => {
 			const success = response.success === true ? 'success' : 'error';
 			const message = response.data.message;
 
 			span.innerHTML = '<span class="notice ' + success + '">' + message + '</span>';
-		});
-	});
+		} );
+	} );
 
-	const saveSettings = document.getElementById('plausible-analytics-save-btn');
+	const formElement = document.getElementById( 'plausible-analytics-settings-form' );
+	
+	// Bailout, if `formElement` doesn't exist.
+	if ( null === formElement ) {
+		return;
+	}
+	
+	const saveSettings = document.getElementById( 'plausible-analytics-save-btn' );
 
-	saveSettings.addEventListener('click', (e) => {
+	saveSettings.addEventListener( 'click', ( e ) => {
 		e.preventDefault();
-		const formData = new FormData(formElement);
+		const formData = new FormData( formElement );
 
-		saveSettings.setAttribute('disabled', 'disabled');
+		saveSettings.setAttribute( 'disabled', 'disabled' );
 
-		formData.append('action', 'plausible_analytics_save_admin_settings');
+		formData.append( 'action', 'plausible_analytics_save_admin_settings' );
 
 		fetch(
 			ajaxurl,
@@ -50,28 +68,28 @@ document.addEventListener('DOMContentLoaded', () => {
 				method: 'POST',
 				body: formData,
 			}
-		).then(response => {
-			if (200 === response.status) {
+		).then( response => {
+			if ( 200 === response.status ) {
 				return response.json();
 			}
 
 			return false;
-		}).then(response => {
-			if (response.error) {
-				saveSettings.querySelector('span').innerText = saveSettings.getAttribute('data-saved-error');
+		} ).then( response => {
+			if ( response.error ) {
+				saveSettings.querySelector( 'span' ).innerText = saveSettings.getAttribute( 'data-saved-error' );
 			}
 
-			if (response.success) {
-				saveSettings.querySelector('span').innerText = saveSettings.getAttribute('data-saved-text');
-				saveSettings.removeAttribute('disabled');
+			if ( response.success ) {
+				saveSettings.querySelector( 'span' ).innerText = saveSettings.getAttribute( 'data-saved-text' );
+				saveSettings.removeAttribute( 'disabled' );
 			}
 
-			setTimeout(() => {
-				saveSettings.removeAttribute('disabled');
-				saveSettings.querySelector('span').innerText = saveSettings.getAttribute('data-default-text');
-			}, 500);
+			setTimeout( () => {
+				saveSettings.removeAttribute( 'disabled' );
+				saveSettings.querySelector( 'span' ).innerText = saveSettings.getAttribute( 'data-default-text' );
+			}, 500 );
 
 			document.location.reload();
-		});
-	});
-});
+		} );
+	} );
+} );

--- a/plausible-analytics.php
+++ b/plausible-analytics.php
@@ -33,6 +33,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// Define plugin version here for convenience.
+define( 'PLAUSIBLE_ANALYTICS_VERSION', '1.2.6' );
+
 require_once __DIR__ . '/config/constants.php';
 
 // Automatically loads files used throughout the plugin.

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -122,7 +122,7 @@ class Actions {
 		if ( wp_remote_retrieve_response_code( $result->get_data() ) === 202 ) {
 			wp_send_json_success(
 				[
-					'message' => __( 'Test traffic sent successfully. Awesome! You can now safely enable the proxy.', 'plausible-analytics' ),
+					'message' => __( 'Test traffic sent successfully. Awesome!', 'plausible-analytics' ),
 					'status'  => 'success',
 				]
 			);

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -122,7 +122,7 @@ class Actions {
 		if ( wp_remote_retrieve_response_code( $result->get_data() ) === 202 ) {
 			wp_send_json_success(
 				[
-					'message' => __( 'Test traffic sent successfully. Awesome!', 'plausible-analytics' ),
+					'message' => __( 'Awesome! Test completed successfully.', 'plausible-analytics' ),
 					'status'  => 'success',
 				]
 			);

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -30,6 +30,7 @@ class Actions {
 	 */
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_assets' ] );
+		add_action( 'wp_ajax_plausible_analytics_notice_dismissed', [ $this, 'dismiss_speed_module_notice' ] );
 		add_action( 'wp_ajax_plausible_analytics_save_admin_settings', [ $this, 'save_admin_settings' ] );
 		add_action( 'wp_ajax_plausible_analytics_test_proxy', [ $this, 'test_proxy' ] );
 	}
@@ -38,13 +39,27 @@ class Actions {
 	 * Register Assets.
 	 *
 	 * @since  1.0.0
+	 * @since  1.3.0 Don't load CSS admin-wide. JS needs to load admin-wide, since we're throwing admin-wide, dismissable notices.
+	 *
 	 * @access public
 	 *
 	 * @return void
 	 */
-	public function register_assets() {
-		\wp_enqueue_style( 'plausible-admin', PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/css/plausible-admin.css', '', filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/css/plausible-admin.css' ), 'all' );
+	public function register_assets( $current_page ) {
+		if ( $current_page === 'settings_page_plausible_analytics' ) {
+			\wp_enqueue_style( 'plausible-admin', PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/css/plausible-admin.css', '', filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/css/plausible-admin.css' ), 'all' );
+		}
+
 		\wp_enqueue_script( 'plausible-admin', PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-admin.js', '', filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-admin.js' ), true );
+	}
+
+	/**
+	 * Marks the Speed Module notice as dismissed.
+	 *
+	 * @return void
+	 */
+	public function dismiss_speed_module_notice() {
+		set_transient( 'plausible_analytics_speed_module_notice_dismissed', true );
 	}
 
 	/**

--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -79,7 +79,7 @@ class Module {
 	}
 
 	/**
-	 * Uninstall the Speed Module when the proxy is disabled.
+	 * Uninstall the Speed Module and all related settings when the proxy is disabled.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -100,6 +100,7 @@ class Module {
 
 		delete_option( 'plausible_analytics_created_mu_plugins_dir' );
 		delete_option( 'plausible_analytics_proxy_speed_module_installed' );
+		delete_option( 'plausible_analytics_proxy_resources' );
 
 		return true;
 	}

--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -37,7 +37,7 @@ class Module {
 	 * @return void
 	 */
 	public function maybe_install_module( $settings ) {
-		if ( ! empty( $settings['avoid_ad_blockers'][0] ) ) {
+		if ( ! empty( $settings['bypass_ad_blockers'][0] ) ) {
 			$this->install();
 		} else {
 			$this->uninstall();

--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -10,6 +10,8 @@
 
 namespace Plausible\Analytics\WP\Admin;
 
+use Plausible\Analytics\WP\Includes\Helpers;
+
 class Module {
 	/**
 	 * Build properties.
@@ -26,7 +28,37 @@ class Module {
 	 * @return void
 	 */
 	private function init() {
+		add_action( 'admin_init', [ $this, 'maybe_show_notice' ] );
+		add_action( 'admin_notices', [ $this, 'print_notices' ] );
 		add_filter( 'pre_update_option_plausible_analytics_settings', [ $this, 'maybe_install_module' ], 10 );
+	}
+
+	/**
+	 * Show an admin-wide notice if the Speed Module failed to install.
+	 *
+	 * When dismissed it will be shown again after 1 day.
+	 *
+	 * @return void
+	 */
+	public function maybe_show_notice() {
+		$settings = Helpers::get_settings();
+
+		if ( ! empty( $settings['proxy_enabled'][0] ) && ! file_exists( WPMU_PLUGIN_DIR . 'plausible-proxy-speed-module.php' ) ) {
+			$this->throw_notice();
+		}
+	}
+
+	/**
+	 * Takes care of printing the notice.
+	 *
+	 * @return void
+	 */
+	public function print_notices() {
+		if ( get_transient( 'plausible_analytics_speed_module_notice_dismissed' ) ) {
+			return;
+		}
+
+		Notice::print_notices();
 	}
 
 	/**
@@ -37,7 +69,7 @@ class Module {
 	 * @return void
 	 */
 	public function maybe_install_module( $settings ) {
-		if ( ! empty( $settings['bypass_ad_blockers'][0] ) ) {
+		if ( ! empty( $settings['proxy_enabled'][0] ) ) {
 			$this->install();
 		} else {
 			$this->uninstall();
@@ -64,18 +96,29 @@ class Module {
 		}
 
 		if ( ! is_dir( WPMU_PLUGIN_DIR ) ) {
-			wp_die( esc_html__( 'Cannot install Plausible Proxy Speed module', 'plausible-analytics' ) );
+			$this->throw_notice();
+
+			return false;
 		}
 
 		$results = copy_dir( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'mu-plugin', WPMU_PLUGIN_DIR );
 
-		if ( is_wp_error( $results ) ) {
-			return $results;
-		}
+		// if ( is_wp_error( $results ) ) {
+			$this->throw_notice();
+
+			return false;
+		// }
 
 		add_option( 'plausible_analytics_proxy_speed_module_installed', true );
 
-		return $results;
+		return true;
+	}
+
+	/**
+	 * @return void
+	 */
+	private function throw_notice() {
+		Notice::set_notice( sprintf( __( 'Plausible Analytics\' proxy is enabled, but the Proxy Speed Module failed to install. Try <a href="%s" target="_blank">installing it manually</a>.', 'plausible-analytics' ), 'https://plausible.io/wordpress-analytics-plugin#if-the-proxy-script-is-slow' ), 'plausible-analytics-module-install-failed', 'error' );
 	}
 
 	/**
@@ -101,6 +144,7 @@ class Module {
 		delete_option( 'plausible_analytics_created_mu_plugins_dir' );
 		delete_option( 'plausible_analytics_proxy_speed_module_installed' );
 		delete_option( 'plausible_analytics_proxy_resources' );
+		delete_transient( 'plausible_analytics_speed_module_notice_dismissed' );
 
 		return true;
 	}

--- a/src/Admin/Notice.php
+++ b/src/Admin/Notice.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Plausible Analytics | Settings API.
+ *
+ * @since 1.3.0
+ *
+ * @package    WordPress
+ * @subpackage Plausible Analytics
+ */
+
+namespace Plausible\Analytics\WP\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+class Notice {
+	const TRANSIENT_NAME = 'plausible_analytics_notice';
+
+	/** @var array $notices */
+	public static $notices = [];
+
+	/**
+	 * @param        $message
+	 * @param string $type (info|warning|error|success)
+	 * @param string $screen_id
+	 * @param bool   $json
+	 * @param int    $code
+	 */
+	public static function set_notice( $message, $message_id = '', $type = 'success', $screen_id = 'all' ) {
+		self::$notices = get_transient( self::TRANSIENT_NAME );
+
+		if ( ! self::$notices ) {
+			self::$notices = [];
+		}
+
+		self::$notices[ $screen_id ][ $type ][ $message_id ] = $message;
+
+		set_transient( self::TRANSIENT_NAME, self::$notices );
+	}
+
+	/**
+	 * Prints notice (if any) grouped by type.
+	 */
+	public static function print_notices() {
+		$admin_notices = get_transient( self::TRANSIENT_NAME );
+
+		if ( is_array( $admin_notices ) ) {
+			$current_screen = get_current_screen();
+
+			foreach ( $admin_notices as $screen => $notice ) {
+				if ( $current_screen->id !== $screen && $screen !== 'all' ) {
+					continue;
+				}
+
+				foreach ( $notice as $type => $message ) {
+					?>
+					<div id="plausible-analytics-message" class="notice notice-<?php echo $type; ?> is-dismissible">
+						<?php foreach ( $message as $line ) : ?>
+							<p><strong><?php echo $line; ?></strong></p>
+						<?php endforeach; ?>
+					</div>
+					<?php
+				}
+			}
+		}
+
+		delete_transient( self::TRANSIENT_NAME );
+	}
+}

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -202,27 +202,6 @@ class API {
 	}
 
 	/**
-	 * Render Button field.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array $field
-	 *
-	 * @return string|false
-	 */
-	public function render_button_field( array $field ) {
-		ob_start();
-		?>
-		<label for="<?php echo $field['slug']; ?>">
-		<?php echo esc_attr( $field['label'] ); ?>
-		</label>
-		<button class="plausible-analytics-btn" type="button" id="plausible-analytics-<?php echo esc_attr( str_replace( '_', '-', $field['slug'] ) ); ?>"><?php echo esc_attr( $field['button_label'] ); ?></button>
-		<span class="plausible-analytics-notice" id="plausible-analytics-notice-<?php echo esc_attr( str_replace( '_', '-', $field['slug'] ) ); ?>"></span>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
 	 * Render just the label, and allow insertion of anything using the hook beside it.
 	 *
 	 * @since 1.3.0

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -107,7 +107,7 @@ class API {
 		$is_checked  = ! is_array( $toggle ) ? checked( $toggle, true, false ) : '';
 		ob_start();
 		?>
-		<div class="plausible-analytics-admin-field">
+		<div class="plausible-analytics-admin-field <?php echo str_replace( '_', '-', $group['slug'] ); ?>">
 			<div class="plausible-analytics-admin-field-header">
 				<label for="">
 				<?php echo $group['label']; ?>
@@ -127,7 +127,7 @@ class API {
 			<?php
 			if ( ! empty( $fields ) ) {
 				foreach ( $fields as $field ) {
-					echo call_user_func( [ $this, "render_{$field['type']}_field" ], $field ) . '<br/>';
+					echo call_user_func( [ $this, "render_{$field['type']}_field" ], $field );
 				}
 			}
 			?>
@@ -213,7 +213,7 @@ class API {
 	public function render_hook_field( array $field ) {
 		ob_start();
 		?>
-		<div class="plausible-analytics-admin-field-row">
+		<div class="plausible-hook">
 		<label for="<?php echo $field['slug']; ?>">
 			<?php echo esc_attr( $field['label'] ); ?>
 		</label>

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -114,7 +114,7 @@ class Page extends API {
 				],
 				[
 					'label'  => esc_html__( 'Bypass ad blockers', 'plausible-analytics' ),
-					'slug'   => 'enable_proxy',
+					'slug'   => 'bypass_ad_blockers',
 					'type'   => 'group',
 					'desc'   => sprintf(
 						wp_kses(
@@ -128,14 +128,9 @@ class Page extends API {
 					'fields' => [
 						[
 							'label' => esc_html__( 'Enable proxy', 'plausible-analytics' ),
-							'slug'  => 'bypass_ad_blockers',
+							'slug'  => 'proxy_enabled',
 							'type'  => 'checkbox',
 							'value' => 'enable',
-						],
-						[
-							'label' => esc_html__( 'Proxy status', 'plausible-analytics' ),
-							'slug'  => 'proxy_status',
-							'type'  => 'hook',
 						],
 						[
 							'label' => esc_html__( 'Test proxy', 'plausible-analytics' ),
@@ -294,7 +289,6 @@ class Page extends API {
 
 		add_action( 'admin_menu', [ $this, 'register_menu' ] );
 		add_action( 'in_admin_header', [ $this, 'render_page_header' ] );
-		add_action( 'plausible_analytics_settings_proxy_status', [ $this, 'proxy_status' ] );
 		add_action( 'plausible_analytics_settings_test_proxy', [ $this, 'test_proxy' ] );
 	}
 
@@ -514,54 +508,13 @@ class Page extends API {
 	}
 
 	/**
-	 * Shows the checkmark to indicate if the Proxy module is properly installed.
-	 *
-	 * @return void
-	 */
-	public function proxy_status( $slug ) {
-		?>
-		<ul id="plausible_analytics_setting_<?php echo $slug; ?>">
-		<?php
-		$proxy_path       = ! empty( Helpers::get_settings()['bypass_ad_blockers'][0] ) ? Helpers::get_data_api_url() : '';
-		$module_installed = $this->get_module_status();
-
-		if ( $proxy_path ) {
-			echo '<li><strong>' . __( 'Proxy URL', 'plausible-analytics' ) . ':</strong> ' . $proxy_path . '</li>';
-		}
-
-		if ( $module_installed ) {
-			echo '<li><strong>' . __( 'Module status', 'plausible-analytics' ) . ':</strong> ' . $module_installed . '</li>';
-		}
-
-		if ( ! $proxy_path && ! $module_installed ) {
-			echo '<em>' . __( 'Proxy disabled.', 'plausible-analytics' ) . '</em>';
-		}
-		?>
-		</ul>
-		<?php
-	}
-
-	/**
-	 * Check if the Proxy Speed Module is installed and create a human readable status message.
-	 *
-	 * @return string
-	 */
-	private function get_module_status() {
-		if ( ! empty( Helpers::get_settings()['bypass_ad_blockers'][0] ) && ! file_exists( WPMU_PLUGIN_DIR . '/plausible-proxy-speed-module.php' ) ) {
-			return '❌ ' . sprintf( __( 'Proxy Speed Module failed to install. Try <a href="%s" target="_blank">installing it manually</a>.', 'plausible-analytics' ), '' );
-		} else {
-			return '';
-		}
-	}
-
-	/**
 	 * Add the Test Proxy button if Bypass ad blockers is enabled.
 	 *
 	 * @param mixed $slug
 	 * @return void
 	 */
 	public function test_proxy( $slug ) {
-		$disabled = empty( Helpers::get_settings()['bypass_ad_blockers'][0] );
+		$disabled = empty( Helpers::get_settings()['proxy_enabled'][0] );
 		?>
 			<button class="plausible-analytics-btn" type="button" <?php echo $disabled ? 'disabled' : ''; ?> <?php echo $disabled ? 'title="' . __( 'Test not available, because Proxy is disabled.', 'plausible-analytics' ) . '"' : ''; ?> id="plausible-analytics-<?php echo esc_attr( str_replace( '_', '-', $slug ) ); ?>"><?php echo esc_attr( __( 'Test', 'plausible-analytics' ) ); ?></button>
 			<span class="plausible-analytics-notice" id="plausible-analytics-notice-<?php echo esc_attr( str_replace( '_', '-', $slug ) ); ?>"></span>

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -118,14 +118,10 @@ class Page extends API {
 					'type'   => 'group',
 					'desc'   => sprintf(
 						wp_kses(
-							__( 'Concerned about ad blockers? You can run the Plausible script as a first-party connection from your domain name to count visitors who use ad blockers. <a href="%s" target="_blank">Learn more &raquo;</a>', 'plausible-analytics' ),
-							[
-								'a' => [
-									'href'   => true,
-									'target' => true,
-								],
-							]
+							__( 'Concerned about ad blockers? You can run the Plausible script as a first-party connection from your domain name to count visitors who use ad blockers. The proxy uses WordPress\' API with a randomly generated endpoint, starting with %1$s. <a href="%2$s" target="_blank">Learn more &raquo;</a>', 'plausible-analytics' ),
+							wp_kses_allowed_html( 'post' )
 						),
+						get_site_url( null, 'wp-json' ),
 						'https://plausible.io/wordpress-analytics-plugin#how-to-enable-a-proxy-to-get-more-accurate-stats'
 					),
 					'toggle' => '',

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -533,12 +533,10 @@ class Page extends API {
 	 * @return string
 	 */
 	private function get_module_status() {
-		if ( file_exists( WPMU_PLUGIN_DIR . '/plausible-proxy-speed-module.php' ) ) {
-			return '✅ ' . sprintf( __( 'Proxy Speed Module is properly installed. <a href="%s" target="_blank">What\'s this?</a>', 'plausible-analytics' ), '' );
-		} elseif ( ! empty( Helpers::get_settings()['avoid_ad_blockers'][0] ) && ! file_exists( WPMU_PLUGIN_DIR . '/plausible-proxy-speed-module.php' ) ) {
+		if ( ! empty( Helpers::get_settings()['avoid_ad_blockers'][0] ) && ! file_exists( WPMU_PLUGIN_DIR . '/plausible-proxy-speed-module.php' ) ) {
 			return '❌ ' . sprintf( __( 'Proxy Speed Module failed to install. Try <a href="%s" target="_blank">installing it manually</a>.', 'plausible-analytics' ), '' );
 		} else {
-			return 'Module not installed, because Avoid ad blocker detection is disabled.';
+			return '';
 		}
 	}
 }

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -57,7 +57,8 @@ class Actions {
 			return;
 		}
 
-		wp_enqueue_script( 'plausible-analytics', Helpers::get_js_url( true ), '', filemtime( Helpers::get_js_path() ) );
+		$version = ! empty( $settings['bypass_ad_blockers'][0] ) ? filemtime( Helpers::get_js_path() ) : PLAUSIBLE_ANALYTICS_VERSION;
+		wp_enqueue_script( 'plausible-analytics', Helpers::get_js_url( true ), '', $version );
 
 		// Goal tracking inline script (Don't disable this as it is required by 404).
 		wp_add_inline_script( 'plausible-analytics', 'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }' );

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -57,7 +57,7 @@ class Actions {
 			return;
 		}
 
-		$version = ! empty( $settings['bypass_ad_blockers'][0] ) ? filemtime( Helpers::get_js_path() ) : PLAUSIBLE_ANALYTICS_VERSION;
+		$version = ! empty( $settings['proxy_enabled'][0] ) ? filemtime( Helpers::get_js_path() ) : PLAUSIBLE_ANALYTICS_VERSION;
 		wp_enqueue_script( 'plausible-analytics', Helpers::get_js_url( true ), '', $version );
 
 		// Goal tracking inline script (Don't disable this as it is required by 404).

--- a/src/Includes/Compatibility.php
+++ b/src/Includes/Compatibility.php
@@ -44,6 +44,13 @@ class Compatibility {
 		if ( defined( 'WPO_VERSION' ) ) {
 			add_filter( 'wp-optimize-minify-default-exclusions', [ $this, 'exclude_plausible_js' ] );
 		}
+
+		// LiteSpeed Cache
+		if ( defined( 'LSCWP_V' ) ) {
+			add_filter( 'litespeed_optimize_js_excludes', [ $this, 'exclude_plausible_js' ] );
+			add_filter( 'litespeed_optm_js_defer_exc', [ $this, 'exclude_plausible_inline_js' ] );
+			add_filter( 'litespeed_optm_gm_js_exc', [ $this, 'exclude_plausible_inline_js' ] );
+		}
 	}
 
 	/**

--- a/src/Includes/Filters.php
+++ b/src/Includes/Filters.php
@@ -45,19 +45,15 @@ class Filters {
 			return $tag;
 		}
 
-		$settings       = Helpers::get_settings();
-		$api_url        = Helpers::get_data_api_url();
-		$domain_name    = esc_html( $settings['domain_name'] );
-		$id_replacement = '';
+		$settings    = Helpers::get_settings();
+		$api_url     = Helpers::get_data_api_url();
+		$domain_name = esc_html( $settings['domain_name'] );
 
-		// If we're loading the compat script, we need the correct id attribute. If not, we can just remove it.
-		if ( isset( $settings['compat'] ) && $settings['compat'][0] === '1' ) {
-			$id_replacement = " id='plausible'";
-		}
+		// We need the correct id attribute for IE compatibility.
+		$id_replacement = " id='plausible'";
+		$tag            = str_replace( " id='plausible-analytics-js'", $id_replacement, $tag );
 
-		$tag = str_replace( " id='plausible-analytics-js'", $id_replacement, $tag );
-
-		$params = "async defer data-domain='{$domain_name}' data-api='{$api_url}'";
+		$params = "defer data-domain='{$domain_name}' data-api='{$api_url}'";
 
 		// Triggered when exclude pages is enabled.
 		if ( ! empty( $settings['excluded_pages'] ) && $settings['excluded_pages'] ) {

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -198,6 +198,10 @@ class Helpers {
 	 * @throws Exception
 	 */
 	public static function get_proxy_resource( $resource_name ) {
+		if ( empty( Helpers::get_settings()['avoid_ad_blockers'][0] ) ) {
+			return '';
+		}
+
 		static $resources;
 
 		if ( $resources === null ) {

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -51,7 +51,7 @@ class Helpers {
 		/**
 		 * If Avoid ad blockers is enabled, return URL to local file.
 		 */
-		if ( $local && ! empty( $settings['bypass_ad_blockers'][0] ) ) {
+		if ( $local && ! empty( $settings['proxy_enabled'][0] ) ) {
 			return esc_url(
 				self::get_proxy_resource( 'cache_url' ) . $file_name . '.js'
 			);
@@ -98,7 +98,7 @@ class Helpers {
 		$settings  = self::get_settings();
 		$file_name = 'plausible';
 
-		if ( $local && ! empty( $settings['bypass_ad_blockers'][0] ) ) {
+		if ( $local && ! empty( $settings['proxy_enabled'][0] ) ) {
 			return self::get_proxy_resource( 'file_alias' );
 		}
 
@@ -176,7 +176,7 @@ class Helpers {
 		$defaults = [
 			'domain_name'             => '',
 			'enhanced_measurements'   => [],
-			'bypass_ad_blockers'      => '',
+			'proxy_enabled'           => '',
 			'shared_link'             => '',
 			'excluded_pages'          => '',
 			'tracked_user_roles'      => [],
@@ -200,7 +200,7 @@ class Helpers {
 	 * @throws Exception
 	 */
 	public static function get_proxy_resource( $resource_name = '' ) {
-		if ( empty( Helpers::get_settings()['bypass_ad_blockers'][0] ) ) {
+		if ( empty( Helpers::get_settings()['proxy_enabled'][0] ) ) {
 			return '';
 		}
 
@@ -247,7 +247,7 @@ class Helpers {
 		$settings = self::get_settings();
 		$url      = 'https://plausible.io/api/event';
 
-		if ( ! empty( $settings['bypass_ad_blockers'][0] ) ) {
+		if ( ! empty( $settings['proxy_enabled'][0] ) ) {
 			$namespace = self::get_proxy_resource( 'namespace' );
 			$base      = self::get_proxy_resource( 'base' );
 			$endpoint  = self::get_proxy_resource( 'endpoint' );

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -51,7 +51,7 @@ class Helpers {
 		/**
 		 * If Avoid ad blockers is enabled, return URL to local file.
 		 */
-		if ( $local && ! empty( $settings['avoid_ad_blockers'][0] ) ) {
+		if ( $local && ! empty( $settings['bypass_ad_blockers'][0] ) ) {
 			return esc_url(
 				self::get_proxy_resource( 'cache_url' ) . $file_name . '.js'
 			);
@@ -98,7 +98,7 @@ class Helpers {
 		$settings  = self::get_settings();
 		$file_name = 'plausible';
 
-		if ( $local && ! empty( $settings['avoid_ad_blockers'][0] ) ) {
+		if ( $local && ! empty( $settings['bypass_ad_blockers'][0] ) ) {
 			return self::get_proxy_resource( 'file_alias' );
 		}
 
@@ -176,7 +176,7 @@ class Helpers {
 		$defaults = [
 			'domain_name'             => '',
 			'enhanced_measurements'   => [],
-			'avoid_ad_blockers'       => '',
+			'bypass_ad_blockers'      => '',
 			'shared_link'             => '',
 			'excluded_pages'          => '',
 			'tracked_user_roles'      => [],
@@ -191,14 +191,16 @@ class Helpers {
 	}
 
 	/**
-	 * Get (and generate/store if non-existent) all necessary proxy resources.
+	 * Get (and generate/store if non-existent) a proxy resource by name.
 	 *
-	 * @param mixed $resource_name
-	 * @return mixed
+	 * @param string $resource_name
+	 *
+	 * @return string Value of resource from DB or empty string if Bypass ad blockers option is disabled.
+	 *
 	 * @throws Exception
 	 */
-	public static function get_proxy_resource( $resource_name ) {
-		if ( empty( Helpers::get_settings()['avoid_ad_blockers'][0] ) ) {
+	public static function get_proxy_resource( $resource_name = '' ) {
+		if ( empty( Helpers::get_settings()['bypass_ad_blockers'][0] ) ) {
 			return '';
 		}
 
@@ -245,7 +247,7 @@ class Helpers {
 		$settings = self::get_settings();
 		$url      = 'https://plausible.io/api/event';
 
-		if ( ! empty( $settings['avoid_ad_blockers'][0] ) ) {
+		if ( ! empty( $settings['bypass_ad_blockers'][0] ) ) {
 			$namespace = self::get_proxy_resource( 'namespace' );
 			$base      = self::get_proxy_resource( 'base' );
 			$endpoint  = self::get_proxy_resource( 'endpoint' );

--- a/src/Includes/Proxy.php
+++ b/src/Includes/Proxy.php
@@ -48,7 +48,7 @@ class Proxy {
 	 *
 	 * @var string
 	 */
-	private $endpoint;
+	private $endpoint = '';
 
 	/**
 	 * Build properties.
@@ -71,7 +71,10 @@ class Proxy {
 	 * @return void
 	 */
 	private function init() {
-		add_action( 'rest_api_init', [ $this, 'register_route' ] );
+		// No need to continue if these values turn up empty.
+		if ( $this->namespace && $this->base && $this->endpoint ) {
+			add_action( 'rest_api_init', [ $this, 'register_route' ] );
+		}
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,7 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 final class Plugin {
-
 	/**
 	 * Registers functionality with WordPress hooks.
 	 *


### PR DESCRIPTION
This PR makes the proxy feature a bit more user friendly, according to @metmarkosaric and @ukutaht's comments. It also fixes a few bugs and adds LiteSpeed Cache compatibility.

Disabled:

![afbeelding](https://user-images.githubusercontent.com/18595395/235907434-a019ec6d-c7f9-4f38-9014-e18cb43e46fa.png)

The test button is disabled, because the API is now disabled if the Proxy feature is disabled (to save memory).

I left the Proxy status box there on purpose, when the Proxy is disabled. So that people expect something to appear there when the proxy is enabled.

Enabled: 

![afbeelding](https://user-images.githubusercontent.com/18595395/235908133-51882eb1-f5f7-47be-a8e9-9714541c5f9c.png)
