### PR TITLE
API endpoint test now runs automatically after enabling the option.

### DIFF
--- a/assets/src/css/admin/general.scss
+++ b/assets/src/css/admin/general.scss
@@ -37,6 +37,15 @@
 			}
 		}
 
+		&.bypass-ad-blockers {
+			.plausible-hook {
+				border: 1px solid #2271b1;
+				border-radius: 3px;
+				background-color: #c1d7e9;
+				padding: 1em 2em;
+			}
+		}
+
 		label {
 			font-weight: 700;
 

--- a/assets/src/js/admin/main.js
+++ b/assets/src/js/admin/main.js
@@ -4,9 +4,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 		if ( dismissButton ) {
 			const form = new FormData();
-	
+
 			form.append( 'action', 'plausible_analytics_notice_dismissed' );
-	
+
 			fetch(
 				ajaxurl,
 				{
@@ -17,41 +17,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		}
 	} );
 
-	const testProxy = document.getElementById( 'plausible-analytics-test-proxy' );
-
-	testProxy.addEventListener( 'click', ( e ) => {
-		e.preventDefault();
-
-		const form = new FormData();
-		const span = document.getElementById( 'plausible-analytics-notice-test-proxy' );
-
-		form.append( 'action', 'plausible_analytics_test_proxy' );
-
-		fetch(
-			ajaxurl,
-			{
-				method: 'POST',
-				body: form,
-			}
-		).then( response => {
-			span.innerHTML = '<span class="plausible-analytics-loading spinner is-active"></span>';
-
-			return response.json();
-		} ).then( response => {
-			const success = response.success === true ? 'success' : 'error';
-			const message = response.data.message;
-
-			span.innerHTML = '<span class="notice ' + success + '">' + message + '</span>';
-		} );
-	} );
-
 	const formElement = document.getElementById( 'plausible-analytics-settings-form' );
-	
+
 	// Bailout, if `formElement` doesn't exist.
 	if ( null === formElement ) {
 		return;
 	}
-	
+
 	const saveSettings = document.getElementById( 'plausible-analytics-save-btn' );
 
 	saveSettings.addEventListener( 'click', ( e ) => {

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -32,7 +32,6 @@ class Actions {
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_assets' ] );
 		add_action( 'wp_ajax_plausible_analytics_notice_dismissed', [ $this, 'dismiss_speed_module_notice' ] );
 		add_action( 'wp_ajax_plausible_analytics_save_admin_settings', [ $this, 'save_admin_settings' ] );
-		add_action( 'wp_ajax_plausible_analytics_test_proxy', [ $this, 'test_proxy' ] );
 	}
 
 	/**
@@ -59,7 +58,7 @@ class Actions {
 	 * @return void
 	 */
 	public function dismiss_speed_module_notice() {
-		set_transient( 'plausible_analytics_speed_module_notice_dismissed', true );
+		set_transient( 'plausible_analytics_notice_dismissed', true );
 	}
 
 	/**
@@ -109,48 +108,5 @@ class Actions {
 				]
 			);
 		}
-	}
-
-	/**
-	 * Test Proxy through AJAX.
-	 *
-	 * @return void
-	 */
-	public function test_proxy() {
-		$namespace = Helpers::get_proxy_resource( 'namespace' );
-		$base      = Helpers::get_proxy_resource( 'base' );
-		$endpoint  = Helpers::get_proxy_resource( 'endpoint' );
-		$request   = new WP_REST_Request( 'POST', "/$namespace/v1/$base/$endpoint" );
-		$request->set_body(
-			wp_json_encode(
-				[
-					'd' => 'plausible.test',
-					'n' => 'pageview',
-					'u' => 'https://plausible.test/test',
-				]
-			)
-		);
-
-		/** @var \WP_REST_Response $result */
-		$result = rest_do_request( $request );
-
-		if ( wp_remote_retrieve_response_code( $result->get_data() ) === 202 ) {
-			wp_send_json_success(
-				[
-					'message' => __( 'Awesome! Test completed successfully.', 'plausible-analytics' ),
-					'status'  => 'success',
-				]
-			);
-		}
-
-		/** @var \WP_Error $error */
-		$error = $result->as_error();
-
-		wp_send_json_error(
-			[
-				'message' => __( 'Oops! Something went wrong while trying to access the API. Please contact us and copy this error message', 'plausible-analytics' ) . ': ' . $error->get_error_code() . ' - ' . $error->get_error_message(),
-				'status'  => 'error',
-			]
-		);
 	}
 }

--- a/src/Admin/Notice.php
+++ b/src/Admin/Notice.php
@@ -62,7 +62,5 @@ class Notice {
 				}
 			}
 		}
-
-		delete_transient( self::TRANSIENT_NAME );
 	}
 }

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -133,8 +133,8 @@ class Page extends API {
 							'value' => 'enable',
 						],
 						[
-							'label' => esc_html__( 'Test proxy', 'plausible-analytics' ),
-							'slug'  => 'test_proxy',
+							'label' => '',
+							'slug'  => 'proxy_warning',
 							'type'  => 'hook',
 						],
 					],
@@ -289,7 +289,7 @@ class Page extends API {
 
 		add_action( 'admin_menu', [ $this, 'register_menu' ] );
 		add_action( 'in_admin_header', [ $this, 'render_page_header' ] );
-		add_action( 'plausible_analytics_settings_test_proxy', [ $this, 'test_proxy' ] );
+		add_action( 'plausible_analytics_settings_proxy_warning', [ $this, 'render_proxy_warning' ] );
 	}
 
 	/**
@@ -507,17 +507,7 @@ class Page extends API {
 		}
 	}
 
-	/**
-	 * Add the Test Proxy button if Bypass ad blockers is enabled.
-	 *
-	 * @param mixed $slug
-	 * @return void
-	 */
-	public function test_proxy( $slug ) {
-		$disabled = empty( Helpers::get_settings()['proxy_enabled'][0] );
-		?>
-			<button class="plausible-analytics-btn" type="button" <?php echo $disabled ? 'disabled' : ''; ?> <?php echo $disabled ? 'title="' . __( 'Test not available, because Proxy is disabled.', 'plausible-analytics' ) . '"' : ''; ?> id="plausible-analytics-<?php echo esc_attr( str_replace( '_', '-', $slug ) ); ?>"><?php echo esc_attr( __( 'Test', 'plausible-analytics' ) ); ?></button>
-			<span class="plausible-analytics-notice" id="plausible-analytics-notice-<?php echo esc_attr( str_replace( '_', '-', $slug ) ); ?>"></span>
-		<?php
+	public function render_proxy_warning() {
+		echo sprintf( wp_kses( __( 'After enabling this option, please check your Plausible dashboard to make sure stats are being recorded. Are stats not being recorded? Do <a href="%s" target="_blank">reach out to us</a>. We\'re here to help!', 'plausible-analytics' ), 'post' ), 'https://plausible.io/contact' );
 	}
 }

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -200,10 +200,6 @@ class Helpers {
 	 * @throws Exception
 	 */
 	public static function get_proxy_resource( $resource_name = '' ) {
-		if ( empty( Helpers::get_settings()['proxy_enabled'][0] ) ) {
-			return '';
-		}
-
 		static $resources;
 
 		if ( $resources === null ) {
@@ -248,11 +244,7 @@ class Helpers {
 		$url      = 'https://plausible.io/api/event';
 
 		if ( ! empty( $settings['proxy_enabled'][0] ) ) {
-			$namespace = self::get_proxy_resource( 'namespace' );
-			$base      = self::get_proxy_resource( 'base' );
-			$endpoint  = self::get_proxy_resource( 'endpoint' );
-
-			return get_rest_url( null, "$namespace/v1/$base/$endpoint" );
+			return self::get_rest_endpoint();
 		}
 
 		// Triggered when self hosted analytics is enabled.
@@ -264,6 +256,27 @@ class Helpers {
 		}
 
 		return esc_url( $url );
+	}
+
+	/**
+	 * Returns the Proxy's REST endpoint.
+	 *
+	 * @return string
+	 *
+	 * @throws Exception
+	 */
+	public static function get_rest_endpoint( $abs_url = true ) {
+		$namespace = self::get_proxy_resource( 'namespace' );
+		$base      = self::get_proxy_resource( 'base' );
+		$endpoint  = self::get_proxy_resource( 'endpoint' );
+
+		$uri = "$namespace/v1/$base/$endpoint";
+
+		if ( $abs_url ) {
+			return get_rest_url( null, $uri );
+		}
+
+		return '/wp-json/' . $uri;
 	}
 
 	/**


### PR DESCRIPTION
the final result is this:
![The setting's section](https://github.com/plausible/wordpress/assets/18595395/9a9a9a2d-bb84-483b-bf40-0f00141d6c9b)

And possible errors that can be thrown after enabling the option are:
![This error can be thrown if the Proxy Speed module failed to install.](https://github.com/plausible/wordpress/assets/18595395/ebc860ab-a16f-4598-a606-fa5a97c42391)

And:

![This error can be thrown if the WordPress API test fails.](https://github.com/plausible/wordpress/assets/18595395/0d9e24a7-ded9-416e-a5f9-4fc2f3ce49ed)

Both errors are shown admin wide, and will not disappear until the "X" is clicked, i.e. the notice is dismissed. This, to ensure people read them.