### PR TITLE
404 tracking

### DIFF
--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -72,6 +72,14 @@ class Page extends API {
 					// translators: %1$s replaced with <code>outbound-links</code>.
 					'desc'   => esc_html__( 'To complete the setup process of a particular enhanced measurement, click on the "Additional action required" link and follow the instructions.', 'plausible-analytics' ),
 					'fields' => [
+						'404'            => [
+							'label'      => esc_html__( ' 404 pages', 'plausible-analytics' ),
+							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-404-error-pages',
+							'docs_label' => esc_html__( 'Additional action required', 'plausible-analytics' ),
+							'slug'       => 'enhanced_measurements',
+							'type'       => 'checkbox',
+							'value'      => '404',
+						],
 						'outbound-links' => [
 							'label'      => esc_html__( 'Outbound links', 'plausible-analytics' ),
 							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-external-link-clicks',

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -64,7 +64,7 @@ class Actions {
 		wp_add_inline_script( 'plausible-analytics', 'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }' );
 
 		// Track 404 pages.
-		if ( apply_filters( 'plausible_analytics_enable_404', true ) && is_404() ) {
+		if ( ! empty( $settings['enhanced_measurements'] ) && in_array( '404', $settings['enhanced_measurements'] ) && is_404() ) {
 			wp_add_inline_script( 'plausible-analytics', 'plausible("404",{ props: { path: document.location.pathname } });' );
 		}
 	}

--- a/src/Includes/Filters.php
+++ b/src/Includes/Filters.php
@@ -52,8 +52,14 @@ class Filters {
 		// We need the correct id attribute for IE compatibility.
 		$id_replacement = " id='plausible'";
 		$tag            = str_replace( " id='plausible-analytics-js'", $id_replacement, $tag );
+		$params         = '';
 
-		$params = "defer data-domain='{$domain_name}' data-api='{$api_url}'";
+		// The defer attribute should only be inserted, if our Proxy is enabled.
+		if ( empty( $settings['proxy_enabled'][0] ) ) {
+			$params = ' defer ';
+		}
+
+		$params = "data-domain='{$domain_name}' data-api='{$api_url}'";
 
 		// Triggered when exclude pages is enabled.
 		if ( ! empty( $settings['excluded_pages'] ) && $settings['excluded_pages'] ) {


### PR DESCRIPTION
This PR adds the 404 tracking as an option to Enhanced Measurements.

It also fixes an issue, in combination when the Proxy is used.

![afbeelding](https://github.com/plausible/wordpress/assets/18595395/4ebe873b-3d06-4465-9207-342ef636b91c)

@metmarkosaric any remarks about the copy?