### PR TITLE
Fixed: wp_kses() would break UTM tags, using wp_kses_no_null() instead.

### DIFF
--- a/src/Includes/Proxy.php
+++ b/src/Includes/Proxy.php
@@ -119,7 +119,7 @@ class Proxy {
 					'X-Forwarded-For' => $ip,
 					'Content-Type'    => 'application/json',
 				],
-				'body'       => wp_kses( $params, 'strip' ),
+				'body'       => wp_kses_no_null( $params ),
 			]
 		);
 


### PR DESCRIPTION
This fixes the bug which would break UTM tags when using the Proxy.