### PR TITLE
Added: disable proxy when self-hosted domain is used and vice versa.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repository is not suitable for support. Please don't use GitHub issues for 
 ### Toggles
 Using constants, you can modify the behavior of the plugin. `wp-config.php` is the best place to define constants. If you're using a custom plugin, make sure its code is loaded before this plugin.
 
-- `PLAUSIBLE_SELF_HOSTED_DOMAIN`: Especially useful for Multisite instances using the self hosted version of Plausible, this constant allows you to specify the Self Hosted Domain for all subsites at once. **IMPORTANT**: this constant takes precedence over the plugin's setting. So, if this constant is defined, changing the setting won't have any effect.
+- `PLAUSIBLE_SELF_HOSTED_DOMAIN`: Especially useful for Multisite instances using the self-hosted version of Plausible, this constant allows you to specify the Self-Hosted Domain for all subsites at once. **IMPORTANT**: this constant takes precedence over the plugin's setting. So, if this constant is defined, changing the setting won't have any effect.
 - `plausible_proxy`: This `GET`-parameter will force enable the proxy. This'll allow you to test your proxy in the frontend, before enabling the option.
 
 ## Local Development 

--- a/assets/src/css/admin/general.scss
+++ b/assets/src/css/admin/general.scss
@@ -13,7 +13,8 @@
 		width: 100%;
 	}
 
-	.plausible-checkbox-list {
+	.plausible-checkbox-list,
+	.plausible-text-field {
 		margin: .5em 1em .5em 0;
 		display: inline-block;
 	}
@@ -43,6 +44,19 @@
 				border-radius: 3px;
 				background-color: #c1d7e9;
 				padding: 1em 2em;
+			}
+		}
+
+		&.is-self-hosted {
+			.plausible-hook {
+				border: 1px solid #2271b1;
+				border-radius: 3px;
+				background-color: #c1d7e9;
+				padding: 1em 2em;
+
+				&:empty {
+					display: none;
+				}
 			}
 		}
 

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -82,11 +82,12 @@ class API {
 		ob_start();
 		$value       = ! empty( $field['value'] ) ? $field['value'] : '';
 		$placeholder = ! empty( $field['placeholder'] ) ? $field['placeholder'] : '';
+		$disabled    = ! empty( $field['disabled'] ) ? 'disabled' : '';
 		?>
-		<label for="<?php echo $field['slug']; ?>">
-		<?php echo esc_attr( $field['label'] ); ?>
-		</label>
-		<input id="<?php echo $field['slug']; ?>" placeholder="<?php echo $placeholder; ?>" type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" />
+		<span class="plausible-text-field">
+			<label for="<?php echo $field['slug']; ?>"><?php echo esc_attr( $field['label'] ); ?></label>
+			<input id="<?php echo $field['slug']; ?>" placeholder="<?php echo $placeholder; ?>" type="text" name="plausible_analytics_settings[<?php echo $field['slug']; ?>]" value="<?php echo $value; ?>" <?php echo $disabled; ?> />
+		</span>
 		<?php
 		return ob_get_clean();
 	}
@@ -154,20 +155,14 @@ class API {
 		$settings = Helpers::get_settings();
 		$slug     = ! empty( $settings[ $field['slug'] ] ) ? $settings[ $field['slug'] ] : '';
 		$id       = $field['slug'] . '_' . str_replace( '-', '_', sanitize_title( $field['label'] ) );
+		$checked  = is_array( $slug ) ? checked( $value, in_array( $value, $slug, false ) ? $value : false, false ) : checked( $value, $slug, false );
+		$disabled = ! empty( $field['disabled'] ) ? 'disabled' : '';
 
 		?>
 		<span class="plausible-checkbox-list">
 			<input id="<?php echo $id; ?>" type="checkbox"
 				name="plausible_analytics_settings[<?php echo esc_attr( $field['slug'] ); ?>][]"
-				value="<?php echo esc_html( $value ); ?>"
-			<?php
-			if ( is_array( $slug ) ) {
-				checked( $value, in_array( $value, $slug, false ) ? $value : false, true );
-			} else {
-				checked( $value, $slug, true );
-			}
-			?>
-			/>
+				value="<?php echo esc_html( $value ); ?>" <?php echo $checked; ?> <?php echo $disabled; ?> />
 			<?php // This trick'll make our option always show up in $_POST. Even when unchecked. ?>
 			<input id="<?php echo $id; ?>" type="hidden" name="plausible_analytics_settings[<?php echo esc_attr( $field['slug'] ); ?>][]" value="0" />
 			<label for="<?php echo $id; ?>"><?php echo $field['label']; ?></label>
@@ -213,14 +208,7 @@ class API {
 	public function render_hook_field( array $field ) {
 		ob_start();
 		?>
-		<div class="plausible-hook">
-		<label for="<?php echo $field['slug']; ?>">
-			<?php echo esc_attr( $field['label'] ); ?>
-		</label>
-		<?php
-		do_action( 'plausible_analytics_settings_' . $field['slug'], $field['slug'] );
-		?>
-		</div>
+		<div class="plausible-hook"><?php do_action( 'plausible_analytics_settings_' . $field['slug'], $field['slug'] ); ?></div>
 		<?php
 
 		return trim( ob_get_clean() );

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -518,7 +518,7 @@ class Page extends API {
 	 */
 	public function render_proxy_warning() {
 		if ( ! empty( Helpers::get_settings()['self_hosted_domain'] ) ) {
-			echo wp_kses( __( 'This option is disabled, because the <strong>Self-hosted Domain</strong> setting is enabled under <em>Self-Hosted</em> settings.', 'plausible-analytics' ), 'post' );
+			echo wp_kses( __( 'This option is disabled, because the <strong>Domain Name</strong> setting is enabled under <em>Self-Hosted</em> settings.', 'plausible-analytics' ), 'post' );
 		} else {
 			echo sprintf( wp_kses( __( 'After enabling this option, please check your Plausible dashboard to make sure stats are being recorded. Are stats not being recorded? Do <a href="%s" target="_blank">reach out to us</a>. We\'re here to help!', 'plausible-analytics' ), 'post' ), 'https://plausible.io/contact' );
 		}

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -37,7 +37,7 @@ class Page extends API {
 		$excluded_pages     = ! empty( $settings['excluded_pages'] ) ? $settings['excluded_pages'] : '';
 		$is_shared_link     = ! empty( $settings['is_shared_link'] ) ? (bool) $settings['is_shared_link'] : false;
 		$is_exclude_pages   = ! empty( $settings['is_exclude_pages'] ) ? (bool) $settings['is_exclude_pages'] : false;
-		$is_selfhosted      = ! empty( $settings['is_self_hosted_plausible_analytics'] ) ? (bool) $settings['is_self_hosted_plausible_analytics'] : false;
+		$is_selfhosted      = ! empty( $settings['is_self_hosted'] ) ? (bool) $settings['is_self_hosted'] : false;
 
 		$this->fields = [
 			'general'     => [
@@ -138,10 +138,11 @@ class Page extends API {
 					'toggle' => '',
 					'fields' => [
 						[
-							'label' => esc_html__( 'Enable proxy', 'plausible-analytics' ),
-							'slug'  => 'proxy_enabled',
-							'type'  => 'checkbox',
-							'value' => 'enable',
+							'label'    => esc_html__( 'Enable proxy', 'plausible-analytics' ),
+							'slug'     => 'proxy_enabled',
+							'type'     => 'checkbox',
+							'value'    => 'enable',
+							'disabled' => ! empty( Helpers::get_settings()['self_hosted_domain'] ),
 						],
 						[
 							'label' => '',
@@ -231,8 +232,8 @@ class Page extends API {
 			],
 			'self-hosted' => [
 				[
-					'label'  => esc_html__( 'Self-hosted Plausible Analytics?', 'plausible-analytics' ),
-					'slug'   => 'is_self_hosted_plausible_analytics',
+					'label'  => esc_html__( 'Self-hosted Plausible Analytics', 'plausible-analytics' ),
+					'slug'   => 'is_self_hosted',
 					'type'   => 'group',
 					'desc'   => sprintf(
 						'%1$s <a href="%2$s" target="_blank">%3$s</a>',
@@ -248,6 +249,12 @@ class Page extends API {
 							'type'        => 'text',
 							'value'       => $self_hosted_domain,
 							'placeholder' => 'e.g. ' . Helpers::get_domain(),
+							'disabled'    => ! empty( Helpers::get_settings()['proxy_enabled'][0] ),
+						],
+						[
+							'label' => '',
+							'slug'  => 'self_hosted_domain_notice',
+							'type'  => 'hook',
 						],
 					],
 				],
@@ -257,6 +264,7 @@ class Page extends API {
 		add_action( 'admin_menu', [ $this, 'register_menu' ] );
 		add_action( 'in_admin_header', [ $this, 'render_page_header' ] );
 		add_action( 'plausible_analytics_settings_proxy_warning', [ $this, 'render_proxy_warning' ] );
+		add_action( 'plausible_analytics_settings_self_hosted_domain_notice', [ $this, 'maybe_render_self_hosted_warning' ] );
 	}
 
 	/**
@@ -381,7 +389,7 @@ class Page extends API {
 					'class' => '' === $current_tab ? 'active' : '',
 				],
 				'self-hosted' => [
-					'name'  => esc_html__( 'Self Hosted', 'plausible-analytics' ),
+					'name'  => esc_html__( 'Self-Hosted', 'plausible-analytics' ),
 					'url'   => admin_url( 'options-general.php?page=plausible_analytics&tab=self-hosted' ),
 					'class' => 'self-hosted' === $current_tab ? 'active' : '',
 				],
@@ -509,7 +517,17 @@ class Page extends API {
 	 * @return void
 	 */
 	public function render_proxy_warning() {
-		echo sprintf( wp_kses( __( 'After enabling this option, please check your Plausible dashboard to make sure stats are being recorded. Are stats not being recorded? Do <a href="%s" target="_blank">reach out to us</a>. We\'re here to help!', 'plausible-analytics' ), 'post' ), 'https://plausible.io/contact' );
+		if ( ! empty( Helpers::get_settings()['self_hosted_domain'] ) ) {
+			echo wp_kses( __( 'This option is disabled, because the <strong>Self-hosted Domain</strong> setting is enabled under <em>Self-Hosted</em> settings.', 'plausible-analytics' ), 'post' );
+		} else {
+			echo sprintf( wp_kses( __( 'After enabling this option, please check your Plausible dashboard to make sure stats are being recorded. Are stats not being recorded? Do <a href="%s" target="_blank">reach out to us</a>. We\'re here to help!', 'plausible-analytics' ), 'post' ), 'https://plausible.io/contact' );
+		}
+	}
+
+	public function maybe_render_self_hosted_warning() {
+		if ( Helpers::proxy_enabled() ) {
+			echo wp_kses( __( 'This option is disabled, because the <strong>Proxy</strong> setting is enabled under <em>General</em> settings.', 'plausible-analytics' ), 'post' );
+		}
 	}
 
 	/**

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -57,7 +57,7 @@ class Helpers {
 			);
 		}
 
-		// Allows for hard-coding the self hosted domain.
+		// Allows for hard-coding the self-hosted domain.
 		if ( defined( 'PLAUSIBLE_SELF_HOSTED_DOMAIN' ) ) {
 			// phpcs:ignore
 			$domain = PLAUSIBLE_SELF_HOSTED_DOMAIN;
@@ -261,7 +261,7 @@ class Helpers {
 			return self::get_rest_endpoint() . $append;
 		}
 
-		// Triggered when self hosted analytics is enabled.
+		// Triggered when self-hosted analytics is enabled.
 		if (
 			! empty( $settings['self_hosted_domain'] )
 		) {


### PR DESCRIPTION
This PR adds the following UX:

When Proxy is enabled, it'll disable the Self-hosted Domain option and show a notice:

![afbeelding](https://github.com/plausible/wordpress/assets/18595395/6a6f6f2a-4ebe-453a-a7ea-f4b690790074)

When Self-hosted Domain option is neabled, it'll disable the Proxy option and show a notice:

![afbeelding](https://github.com/plausible/wordpress/assets/18595395/0a2e1354-ddc8-4a5c-91bf-10bdf122811c)
