### PR TITLE
Preserve `%2F` in Shared Link

### DIFF
--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -370,11 +370,25 @@ class Helpers {
 	 * @return string|array
 	 */
 	public static function clean( $var ) {
+		// If the variable is an array, recursively apply the function to each element of the array.
 		if ( is_array( $var ) ) {
 			return array_map( [ __CLASS__, __METHOD__ ], $var );
 		}
 
-		return is_scalar( $var ) ? sanitize_text_field( wp_unslash( $var ) ) : $var;
+		// If the variable is a scalar value (string, integer, float, boolean).
+		if ( is_scalar( $var ) ) {
+			// Parse the variable using the wp_parse_url function.
+			$parsed = wp_parse_url( $var );
+			// If the variable has a scheme (e.g. http:// or https://), sanitize the variable using the esc_url_raw function.
+			if ( isset( $parsed['scheme'] ) ) {
+				return esc_url_raw( wp_unslash( $var ), [ $parsed['scheme'] ] );
+			}
+			// If the variable does not have a scheme, sanitize the variable using the sanitize_text_field function.
+			return sanitize_text_field( wp_unslash( $var ) );
+		}
+
+		// If the variable is not an array or a scalar value, return the variable unchanged.
+		return $var;
 	}
 
 	/**


### PR DESCRIPTION
Preserve `%2F` in Shared Link when WordPress is installed in subdirectory, or Plausible is running on a multisite subsite. Will fix #53