### PR TITLE
Clean up proxy files after disabling option

### DIFF
--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -140,7 +140,7 @@ class Module {
 	}
 
 	/**
-	 * Uninstall the Speed Module and all related settings when the proxy is disabled.
+	 * Uninstall the Speed Module, generates JS files and all related settings when the proxy is disabled.
 	 *
 	 * @since 1.3.0
 	 *
@@ -151,6 +151,9 @@ class Module {
 			return false;
 		}
 
+		/**
+		 * Clean up MU plugin.
+		 */
 		$file_path = WP_CONTENT_DIR . '/mu-plugins/plausible-proxy-speed-module.php';
 
 		if ( file_exists( $file_path ) ) {
@@ -161,6 +164,23 @@ class Module {
 			rmdir( WPMU_PLUGIN_DIR );
 		}
 
+		/**
+		 * Clean up generated JS files in /uploads dir.
+		 */
+		$cache_dir = Helpers::get_proxy_resource( 'cache_dir' );
+		$js_file   = Helpers::get_proxy_resource( 'file_alias' );
+
+		if ( file_exists( $cache_dir . $js_file . '.js' ) ) {
+			unlink( $cache_dir . $js_file . '.js' );
+		}
+
+		if ( $this->dir_is_empty( $cache_dir ) ) {
+			rmdir( $cache_dir );
+		}
+
+		/**
+		 * Clean up related DB entries.
+		 */
 		delete_option( 'plausible_analytics_created_mu_plugins_dir' );
 		delete_option( 'plausible_analytics_proxy_speed_module_installed' );
 		delete_option( 'plausible_analytics_proxy_resources' );

--- a/src/Admin/Upgrades.php
+++ b/src/Admin/Upgrades.php
@@ -10,6 +10,7 @@
 
 namespace Plausible\Analytics\WP\Admin;
 
+use Exception;
 use Plausible\Analytics\WP\Includes\Helpers;
 
 // Bailout, if accessed directly.
@@ -65,12 +66,29 @@ class Upgrades {
 			$this->upgrade_to_131();
 		}
 
-		// Upgrade to version 1.3.0.
-		// if ( version_compare( $plausible_analytics_version, '1.3.0', '<' ) ) {
-		// 	$this->upgrade_to_130();
-		// }
+		if ( version_compare( $plausible_analytics_version, '1.3.2', '<' ) ) {
+			$this->upgrade_to_132();
+		}
 
 		// Add required upgrade routines for future versions here.
+	}
+
+	/**
+	 * Upgrade to 1.3.2
+	 *
+	 * - Updates the Proxy Resource, Cache URL to be protocol relative.
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	private function upgrade_to_132() {
+		$proxy_resources = Helpers::get_proxy_resources();
+
+		$proxy_resources['cache_url'] = str_replace( [ 'https:', 'http:' ], '', $proxy_resources['cache_url'] );
+
+		update_option( 'plausible_analytics_proxy_resources', $proxy_resources );
+
+		update_option( 'plausible_analytics_version', '1.3.2' );
 	}
 
 	/**
@@ -150,27 +168,5 @@ class Upgrades {
 		update_option( 'plausible_analytics_settings', $new_settings );
 
 		update_option( 'plausible_analytics_version', '1.2.5' );
-	}
-
-	/**
-	 * Upgrade routine for 1.3.0
-	 *
-	 * @since  1.3.0
-	 * @access public
-	 *
-	 * @return void
-	 */
-	public function upgrade_to_130() {
-		$old_settings = Helpers::get_settings();
-		$new_settings = $old_settings;
-
-		$old_embed_analytics            = ! empty( $old_settings['embed_analytics'] ) ? $old_settings['embed_analytics'] : '';
-		$new_settings['is_shared_link'] = $old_embed_analytics;
-
-		// Update the new settings.
-		update_option( 'plausible_analytics_settings', $new_settings );
-
-		// Update the version in DB to the latest as upgrades completed.
-		update_option( 'plausible_analytics_version', '1.3.0' );
 	}
 }

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -57,7 +57,7 @@ class Actions {
 			return;
 		}
 
-		$version = Helpers::proxy_enabled() ? filemtime( Helpers::get_js_path() ) : PLAUSIBLE_ANALYTICS_VERSION;
+		$version = Helpers::proxy_enabled() && file_exists( Helpers::get_js_path() ) ? filemtime( Helpers::get_js_path() ) : PLAUSIBLE_ANALYTICS_VERSION;
 		wp_enqueue_script( 'plausible-analytics', Helpers::get_js_url( true ), '', $version, apply_filters( 'plausible_load_js_in_footer', false ) );
 
 		// Goal tracking inline script (Don't disable this as it is required by 404).

--- a/src/Includes/Cron.php
+++ b/src/Includes/Cron.php
@@ -29,6 +29,7 @@ class Cron {
 	 * Run
 	 *
 	 * @return void
+	 *
 	 * @throws InvalidArgument
 	 * @throws Exception
 	 */
@@ -44,13 +45,18 @@ class Cron {
 	}
 
 	/**
-	 * Download the plausible.js file and download it to the uploads directory with an alias.
+	 * Download the plausible.js file if the Proxy is enabled and downloads it to the uploads directory with an alias.
 	 *
 	 * @return bool
+	 *
 	 * @throws InvalidArgument
 	 * @throws Exception
 	 */
 	private function download() {
+		if ( ! Helpers::proxy_enabled() ) {
+			return false;
+		}
+
 		$remote = Helpers::get_js_url();
 		$local  = Helpers::get_js_path();
 

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -202,7 +202,7 @@ class Helpers {
 	}
 
 	/**
-	 * Get (and generate/store if non-existent) a proxy resource by name.
+	 * Get a proxy resource by name.
 	 *
 	 * @param string $resource_name
 	 *
@@ -211,6 +211,24 @@ class Helpers {
 	 * @throws Exception
 	 */
 	public static function get_proxy_resource( $resource_name = '' ) {
+		$resources = self::get_proxy_resources();
+
+		/**
+		 * Create the cache directory if it doesn't exist.
+		 */
+		if ( $resource_name === 'cache_dir' && ! is_dir( $resources[ $resource_name ] ) ) {
+			wp_mkdir_p( $resources[ $resource_name ] );
+		}
+
+		return isset( $resources[ $resource_name ] ) ? $resources[ $resource_name ] : '';
+	}
+
+	/**
+	 * Get (and generate/store if non-existent) proxy resources.
+	 *
+	 * @return array
+	 */
+	public static function get_proxy_resources() {
 		static $resources;
 
 		if ( $resources === null ) {
@@ -232,14 +250,7 @@ class Helpers {
 			update_option( 'plausible_analytics_proxy_resources', $resources );
 		}
 
-		/**
-		 * Create the cache directory if it doesn't exist.
-		 */
-		if ( $resource_name === 'cache_dir' && ! is_dir( $resources[ $resource_name ] ) ) {
-			wp_mkdir_p( $resources[ $resource_name ] );
-		}
-
-		return isset( $resources[ $resource_name ] ) ? $resources[ $resource_name ] : '';
+		return $resources;
 	}
 
 	/**

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -225,7 +225,7 @@ class Helpers {
 				'base'       => bin2hex( random_bytes( 2 ) ),
 				'endpoint'   => bin2hex( random_bytes( 4 ) ),
 				'cache_dir'  => trailingslashit( $upload_dir['basedir'] ) . trailingslashit( $cache_dir ),
-				'cache_url'  => trailingslashit( $upload_dir['baseurl'] ) . trailingslashit( $cache_dir ),
+				'cache_url'  => str_replace( [ 'https:', 'http:' ], '', trailingslashit( $upload_dir['baseurl'] ) . trailingslashit( $cache_dir ) ),
 				'file_alias' => bin2hex( random_bytes( 4 ) ),
 			];
 
@@ -287,7 +287,7 @@ class Helpers {
 		$uri = "$namespace/v1/$base/$endpoint";
 
 		if ( $abs_url ) {
-			return get_rest_url( null, $uri );
+			return str_replace( [ 'https:', 'http:' ], '', get_rest_url( null, $uri ) );
 		}
 
 		return '/wp-json/' . $uri;

--- a/src/Includes/Setup.php
+++ b/src/Includes/Setup.php
@@ -27,6 +27,8 @@ class Setup {
 		register_activation_hook( PLAUSIBLE_ANALYTICS_PLUGIN_FILE, [ $this, 'create_cache_dir' ] );
 		register_activation_hook( PLAUSIBLE_ANALYTICS_PLUGIN_FILE, [ $this, 'activate_cron' ] );
 		register_deactivation_hook( PLAUSIBLE_ANALYTICS_PLUGIN_FILE, [ $this, 'deactivate_cron' ] );
+
+		// Attach the cron script to the cron action.
 		add_action( $this->cron, [ $this, 'load_cron_script' ] );
 
 		// This assures that the local file is updated when settings are saved.


### PR DESCRIPTION
This PR resolves a few related to the Proxy.

- Files weren't properly cleaned up when the proxy was disabled. Multiple times enabling/disabling would lead to a jungle of files and folders with randomly generated filenames.
- The Proxy Resource `cache_url` will from now on be saved as protocol relative, to prevent mixed content issues when people switch from or to SSL (https://) like in issue https://github.com/plausible/wordpress/issues/150
- The external file would be downloaded and stored in the wp-content/uploads folder, even when the proxy was disabled.