### PR TITLE
Added disabled/checked Administrator role to "Show stats to..." setting.

### DIFF
--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -147,7 +147,7 @@ class API {
 		$settings = Helpers::get_settings();
 		$slug     = ! empty( $settings[ $field['slug'] ] ) ? $settings[ $field['slug'] ] : '';
 		$id       = $field['slug'] . '_' . str_replace( '-', '_', sanitize_title( $field['label'] ) );
-		$checked  = is_array( $slug ) ? checked( $value, in_array( $value, $slug, false ) ? $value : false, false ) : checked( $value, $slug, false );
+		$checked  = ! empty( $field['checked'] ) ? 'checked="checked"' : ( is_array( $slug ) ? checked( $value, in_array( $value, $slug, false ) ? $value : false, false ) : checked( $value, $slug, false ) );
 		$disabled = ! empty( $field['disabled'] ) ? 'disabled' : '';
 
 		?>

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -206,7 +206,7 @@ class Page extends API {
 					'type'   => 'group',
 					'desc'   => esc_html__( 'By default, the stats dashboard is only available to logged in administrators. If you want the dashboard to be available for other logged in users, then please specify them above.', 'plausible-analytics' ),
 					'toggle' => false,
-					'fields' => $this->build_user_roles_array( 'expand_dashboard_access', [ 'administrator' ] ),
+					'fields' => $this->build_user_roles_array( 'expand_dashboard_access', [ 'administrator' => true ] ),
 				],
 				[
 					'label'         => esc_html__( 'Disable menu in toolbar', 'plausible-analytics' ),
@@ -514,6 +514,13 @@ class Page extends API {
 		}
 	}
 
+	/**
+	 * Renders the Self-hosted warning if the Proxy is enabled.
+	 *
+	 * @since 1.3.3
+	 *
+	 * @return void
+	 */
 	public function maybe_render_self_hosted_warning() {
 		if ( Helpers::proxy_enabled() ) {
 			echo wp_kses( __( 'This option is disabled, because the <strong>Proxy</strong> setting is enabled under <em>General</em> settings.', 'plausible-analytics' ), 'post' );
@@ -527,20 +534,24 @@ class Page extends API {
 	 *
 	 * @return array
 	 */
-	private function build_user_roles_array( $slug, $filter_elements = [] ) {
+	private function build_user_roles_array( $slug, $disable_elements = [] ) {
 		$wp_roles = wp_roles()->roles ?? [];
 
 		foreach ( $wp_roles as $id => $role ) {
-			if ( in_array( $id, $filter_elements, true ) ) {
-				continue;
-			}
-
 			$roles_array[ $id ] = [
 				'label' => $role['name'] ?? '',
 				'slug'  => $slug,
 				'type'  => 'checkbox',
 				'value' => $id,
 			];
+
+			if ( in_array( $id, array_keys( $disable_elements ), true ) ) {
+				$roles_array[ $id ]['disabled'] = true;
+
+				if ( ! empty( $disable_elements[ $id ] ) ) {
+					$roles_array[ $id ]['checked'] = $disable_elements[ $id ];
+				}
+			}
 		}
 
 		ksort( $roles_array, SORT_STRING );


### PR DESCRIPTION
This PR adds a disabled and checked 'Administrator' checkbox to the list of user roles for the Show stats to... setting:

![afbeelding](https://github.com/plausible/wordpress/assets/18595395/02fc3d66-2ad8-4564-9ef6-b827a639e2ad)

This fixes https://github.com/plausible/wordpress/issues/153
