### PR TITLE
SiteGround Optimizer compatibility fixes.

### DIFF
--- a/src/Includes/Compatibility.php
+++ b/src/Includes/Compatibility.php
@@ -38,11 +38,12 @@ class Compatibility {
 		}
 
 		// SG Optimizer
-		if ( defined( 'SiteGround_Optimizer\VERSION' ) ) {
+		if ( defined( '\SiteGround_Optimizer\VERSION' ) ) {
 			add_filter( 'sgo_javascript_combine_exclude', [ $this, 'exclude_js_by_handle' ] );
 			add_filter( 'sgo_js_minify_exclude', [ $this, 'exclude_js_by_handle' ] );
 			add_filter( 'sgo_js_async_exclude', [ $this, 'exclude_js_by_handle' ] );
 			add_filter( 'sgo_javascript_combine_excluded_inline_content', [ $this, 'exclude_plausible_inline_js' ] );
+			add_filter( 'sgo_javascript_combine_excluded_external_paths', [ $this, 'exclude_plausible_js' ] );
 		}
 
 		// WP Optimize

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -38,7 +38,8 @@ class Helpers {
 	 * Get Analytics URL.
 	 *
 	 * @since  1.0.0
-	 * @access public
+	 *
+	 * @param bool $local Return the Local JS file IF proxy is enabled.
 	 *
 	 * @return string
 	 */
@@ -235,6 +236,13 @@ class Helpers {
 			$resources = get_option( 'plausible_analytics_proxy_resources', [] );
 		}
 
+		/**
+		 * Force a refresh of our resources if the user recently switched to SSL and we still have non-SSL resources stored.
+		 */
+		if ( ! empty( $resources ) && is_ssl() && isset( $resources['cache_url'] ) && ( strpos( $resources['cache_url'], 'http:' ) !== false ) ) {
+			$resources = [];
+		}
+
 		if ( empty( $resources ) ) {
 			$cache_dir  = bin2hex( random_bytes( 5 ) );
 			$upload_dir = wp_get_upload_dir();
@@ -243,7 +251,7 @@ class Helpers {
 				'base'       => bin2hex( random_bytes( 2 ) ),
 				'endpoint'   => bin2hex( random_bytes( 4 ) ),
 				'cache_dir'  => trailingslashit( $upload_dir['basedir'] ) . trailingslashit( $cache_dir ),
-				'cache_url'  => str_replace( [ 'https:', 'http:' ], '', trailingslashit( $upload_dir['baseurl'] ) . trailingslashit( $cache_dir ) ),
+				'cache_url'  => trailingslashit( $upload_dir['baseurl'] ) . trailingslashit( $cache_dir ),
 				'file_alias' => bin2hex( random_bytes( 4 ) ),
 			];
 


### PR DESCRIPTION
There were two issues remaining in the compatibility with SiteGround Optimizer:

- The external JS library (when Proxy is disabled) wasn't properly excluded from optimization.
- Due to [a bug](https://wordpress.org/support/topic/protocol-relative-urls-cant-be-excluded-using-a-filter/) in SGO, protocol relative URLs (for local resources) weren't handled properly when attempting to exclude them, resulting in the local JS library (when Proxy is enabled) still being included in SGO's combined JS file.