### PR TITLE
Admin: Disable the self-hosted domain field if it's hard-coded

### DIFF
--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -244,7 +244,7 @@ class Page extends API {
 							'type'        => 'text',
 							'value'       => $self_hosted_domain,
 							'placeholder' => 'e.g. ' . Helpers::get_domain(),
-							'disabled'    => ! empty( Helpers::get_settings()['proxy_enabled'][0] ),
+							'disabled'    => ! empty( Helpers::get_settings()['proxy_enabled'][0] ) || defined('PLAUSIBLE_SELF_HOSTED_DOMAIN'),
 						],
 						[
 							'label' => '',


### PR DESCRIPTION
If we define the `PLAUSIBLE_SELF_HOSTED_DOMAIN` constant, we shouldn't allow you to edit the settings field. Disabling this text field makes it more obvious that you can't.