### PR TITLE
Ensure the extension array in Helpers is indeed an array

### DIFF
--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -96,7 +96,7 @@ class Helpers {
 		}
 
 		foreach ( [ 'outbound-links', 'file-downloads', 'tagged-events', 'revenue', 'pageview-props', 'compat', 'hash' ] as $extension ) {
-			if ( in_array( $extension, $settings[ 'enhanced_measurements' ], true ) ) {
+			if ( is_array($extension) && in_array( $extension, $settings[ 'enhanced_measurements' ], true ) ) {
 				$file_name .= '.' . $extension;
 			}
 		}


### PR DESCRIPTION
Solves the fatal error when no options are set in the plugin, and ensures the $extension array exists.

Fixes #175 