### PR TITLE
removing one tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plausible Analytics ===
 Contributors: plausible, DaanvandenBergh
 Donate link: https://plausible.io/
-Tags: analytics, google analytics, web analytics, stats, privacy, privacy-friendly
+Tags: analytics, google analytics, web analytics, stats, privacy
 Requires at least: 5.3
 Tested up to: 6.4
 Requires PHP: 7.0


### PR DESCRIPTION
saw this message on our wordpress plugin page so removing one tag:

"During the last import of your plugin the following warnings were encountered. This message is visible only to the plugin authors & committers.
Readme: One or more tags were ignored. Please limit your plugin to 5 tags."