### PR TITLE
Remove page reload

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -83,4 +83,4 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: Dan0sz/host-webfonts-locally
+          slug: plausible/wordpress

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Generate code coverage
         working-directory: ./
-        run: ./vendor/bin/phpunit --configuration phpunit-with-integration.xml --coverage-clover ./build/clover.xml
+        run: ./vendor/bin/phpunit --configuration phpunit-with-integration.xml --coverage-clover clover.xml .
         continue-on-error: true
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Generate code coverage
         working-directory: ./
-        run: ./vendor/bin/phpunit --configuration phpunit-with-integration.xml --coverage-clover clover.xml .
+        run: ./vendor/bin/phpunit --configuration phpunit-with-integration.xml --coverage-clover ./build/clover.xml
         continue-on-error: true
 
       - name: Upload coverage reports to Codecov

--- a/assets/src/js/admin/main.js
+++ b/assets/src/js/admin/main.js
@@ -130,6 +130,12 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
+				let is_wizard = document.getElementById('plausible-analytics-wizard');
+
+				if (is_wizard !== undefined) {
+					return;
+				}
+
 				if (response.additional !== undefined) {
 					plausible.renderAdditionalMessages(response.additional, e.target);
 				} else {
@@ -288,7 +294,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			data.append('action', 'plausible_analytics_show_wizard');
 			data.append('_nonce', e.target.dataset.nonce);
 
-			plausible.ajax(data, null, false);
+			plausible.ajax(data, null);
 		},
 
 		/**
@@ -383,9 +389,13 @@ document.addEventListener('DOMContentLoaded', () => {
 				return false;
 			}).then(response => {
 				if (response.success === true) {
-					plausible.notice(response.data.message);
+					if (plausible.data !== undefined && plausible.data.message !== undefined) {
+						plausible.notice(response.data.message);
+					}
 				} else {
-					plausible.notice(response.data.message, true);
+					if (plausible.data !== undefined && plausible.data.message !== undefined) {
+						plausible.notice(response.data.message, true);
+					}
 				}
 
 				let event = new CustomEvent('plausibleAjaxDone', {detail: response});

--- a/assets/src/js/admin/main.js
+++ b/assets/src/js/admin/main.js
@@ -72,6 +72,11 @@ document.addEventListener('DOMContentLoaded', () => {
 					this.stepElems[i].addEventListener('click', this.saveOptionOnNext);
 				}
 			}
+
+			/**
+			 * Run once on pageload.
+			 */
+			this.showMessages();
 		},
 
 		/**
@@ -121,63 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			form.append('is_list', button.dataset.list);
 			form.append('_nonce', plausible.nonce);
 
-			let result = plausible.ajax(form, null);
-
-			result.then(function (response) {
-				if (response.success === false) {
-					plausible.toggleOption(e, false);
-
-					return;
-				}
-
-				let is_wizard = document.getElementById('plausible-analytics-wizard');
-
-				if (is_wizard !== null) {
-					return;
-				}
-
-				if (response.additional !== undefined) {
-					plausible.renderAdditionalMessages(response.additional, e.target);
-				} else {
-					plausible.removeAdditionalMessage(e.target);
-				}
-			});
-		},
-
-		/**
-		 * Renders a HTML box containing additional information about the enabled option.
-		 *
-		 * @param html
-		 * @param target
-		 */
-		renderAdditionalMessages: function (html, target) {
-			let container = target.closest('.plausible-analytics-group');
-
-			container.innerHTML += html;
-		},
-
-		/**
-		 * Removes the additional information box when the option is disabled.
-		 *
-		 * @param target
-		 */
-		removeAdditionalMessage: function (target) {
-			let container = target.closest('.plausible-analytics-group');
-			let additionalMessage;
-
-			if (container.children.length > 0) {
-				for (let i = 0; i < container.children.length; i++) {
-					if (container.children[i].classList.contains('plausible-analytics-hook')) {
-						additionalMessage = container.children[i];
-
-						break;
-					}
-				}
-			}
-
-			if (additionalMessage !== undefined) {
-				container.removeChild(additionalMessage);
-			}
+			plausible.ajax(form);
 		},
 
 		/**
@@ -203,7 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			button.children[0].classList.remove('hidden');
 			button.setAttribute('disabled', 'disabled');
 
-			plausible.ajax(form, button, null);
+			plausible.ajax(form, button);
 		},
 
 		/**
@@ -228,7 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				data.append('options', JSON.stringify(options));
 				data.append('_nonce', plausible.nonce);
 
-				plausible.ajax(data, null, false);
+				plausible.ajax(data);
 			}
 		},
 
@@ -296,7 +245,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			data.append('action', 'plausible_analytics_show_wizard');
 			data.append('_nonce', e.target.dataset.nonce);
 
-			plausible.ajax(data, null);
+			plausible.ajax(data);
 		},
 
 		/**
@@ -364,14 +313,15 @@ document.addEventListener('DOMContentLoaded', () => {
 		},
 
 		/**
-		 * Do AJAX request and (optionally) show a notice or (optionally) reload the page.
+		 * Do AJAX request.
 		 *
 		 * @param data
 		 * @param button
+		 * @param showMessages
 		 *
 		 * @return object
 		 */
-		ajax: function (data, button = null) {
+		ajax: function (data, button = null, showMessages = true) {
 			return fetch(
 				ajaxurl,
 				{
@@ -390,14 +340,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				return false;
 			}).then(response => {
-				if (response.success === true) {
-					if (response.data !== undefined && response.data.message !== undefined) {
-						plausible.notice(response.data.message);
-					}
-				} else {
-					if (response.data !== undefined && response.data.message !== undefined) {
-						plausible.notice(response.data.message, true);
-					}
+				if (showMessages === true) {
+					plausible.showMessages();
 				}
 
 				let event = new CustomEvent('plausibleAjaxDone', {detail: response});
@@ -409,18 +353,65 @@ document.addEventListener('DOMContentLoaded', () => {
 		},
 
 		/**
+		 * Show messages on screen.
+		 */
+		showMessages: function () {
+			let messages = plausible.fetchMessages();
+
+			messages.then(function (messages) {
+				if (messages.error !== false) {
+					plausible.showMessage(messages.error, 'error');
+				} else if (messages.notice !== false) {
+					plausible.showMessage(messages.notice, 'notice');
+				} else if (messages.success !== false) {
+					plausible.showMessage(messages.success, 'success');
+				}
+
+				if (messages.additional.length === 0) {
+					return;
+				}
+
+				if (messages.additional.id !== undefined && messages.additional.message) {
+					plausible.showAdditionalMessage(messages.additional.message, messages.additional.id);
+				} else if (messages.additional.id !== undefined && messages.additional.message === '') {
+					plausible.removeAdditionalMessage(messages.additional.id);
+				}
+			});
+		},
+
+		/**
+		 * Fetch the messages for display.
+		 */
+		fetchMessages: function () {
+			let data = new FormData();
+			data.append('action', 'plausible_analytics_messages');
+
+			let result = plausible.ajax(data, null, false);
+
+			return result.then(function (response) {
+				return response;
+			});
+		},
+
+		/**
 		 * Displays a notice or error message.
 		 *
 		 * @param message
-		 * @param isError
+		 * @param type error|warning|success Defaults to success.
 		 */
-		notice: function (message, isError = false) {
-			if (isError === true) {
+		showMessage: function (message, type = 'success') {
+			if (type === 'error') {
 				document.getElementById('icon-error').classList.remove('hidden');
-				document.getElementById('icon-success').classList += ' hidden';
+				document.getElementById('icon-success').classList.add('hidden');
+				document.getElementById('icon-notice').classList.add('hidden');
+			} else if (type === 'notice') {
+				document.getElementById('icon-notice').classList.remove('hidden');
+				document.getElementById('icon-error').classList.add('hidden');
+				document.getElementById('icon-success').classList.add('hidden');
 			} else {
 				document.getElementById('icon-success').classList.remove('hidden');
-				document.getElementById('icon-error').classList += ' hidden';
+				document.getElementById('icon-error').classList.add('hidden');
+				document.getElementById('icon-notice').classList.add('hidden');
 			}
 
 			let notice = document.getElementById('plausible-analytics-notice');
@@ -433,13 +424,50 @@ document.addEventListener('DOMContentLoaded', () => {
 				notice.classList.replace('opacity-0', 'opacity-100');
 			}, 200)
 
-			if (isError === false) {
+			if (type !== 'error') {
 				setTimeout(function () {
 					notice.classList.replace('opacity-100', 'opacity-0');
 					setTimeout(function () {
 						notice.classList += ' hidden';
 					}, 200)
 				}, 2000);
+			}
+		},
+		/**
+		 * Renders a HTML box containing additional information about the enabled option.
+		 *
+		 * @param html
+		 * @param target
+		 */
+		showAdditionalMessage: function (html, target) {
+			let targetElem = document.querySelector(`[name='${target}']`);
+			let container = targetElem.closest('.plausible-analytics-group');
+
+			container.innerHTML += html;
+		},
+
+		/**
+		 * Removes the additional information box when the option is disabled.
+		 *
+		 * @param target
+		 */
+		removeAdditionalMessage: function (target) {
+			let targetElem = document.querySelector(`[name="${target}"]`);
+			let container = targetElem.closest('.plausible-analytics-group');
+			let additionalMessage;
+
+			if (container.children.length > 0) {
+				for (let i = 0; i < container.children.length; i++) {
+					if (container.children[i].classList.contains('plausible-analytics-hook')) {
+						additionalMessage = container.children[i];
+
+						break;
+					}
+				}
+			}
+
+			if (additionalMessage !== undefined) {
+				container.removeChild(additionalMessage);
 			}
 		}
 	}

--- a/assets/src/js/admin/main.js
+++ b/assets/src/js/admin/main.js
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				let is_wizard = document.getElementById('plausible-analytics-wizard');
 
-				if (is_wizard !== undefined) {
+				if (is_wizard !== null) {
 					return;
 				}
 
@@ -175,7 +175,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				}
 			}
 
-			container.removeChild(additionalMessage);
+			if (additionalMessage !== undefined) {
+				container.removeChild(additionalMessage);
+			}
 		},
 
 		/**
@@ -389,11 +391,11 @@ document.addEventListener('DOMContentLoaded', () => {
 				return false;
 			}).then(response => {
 				if (response.success === true) {
-					if (plausible.data !== undefined && plausible.data.message !== undefined) {
+					if (response.data !== undefined && response.data.message !== undefined) {
 						plausible.notice(response.data.message);
 					}
 				} else {
-					if (plausible.data !== undefined && plausible.data.message !== undefined) {
+					if (response.data !== undefined && response.data.message !== undefined) {
 						plausible.notice(response.data.message, true);
 					}
 				}

--- a/phpunit-with-integration.xml
+++ b/phpunit-with-integration.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="false"
-         beStrictAboutCoversAnnotation="false"
-         beStrictAboutOutputDuringTests="false"
-         beStrictAboutTodoAnnotatedTests="false"
-         convertDeprecationsToExceptions="false"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <php>
-        <const name="DAAN_DOING_TESTS" value="true"/>
-    </php>
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+		 bootstrap="tests/bootstrap.php"
+		 cacheResultFile=".phpunit.cache/test-results"
+		 executionOrder="depends,defects"
+		 forceCoversAnnotation="false"
+		 beStrictAboutCoversAnnotation="false"
+		 beStrictAboutOutputDuringTests="false"
+		 beStrictAboutTodoAnnotatedTests="false"
+		 convertDeprecationsToExceptions="false"
+		 failOnRisky="true"
+		 failOnWarning="true"
+		 verbose="true">
+	<php>
+		<const name="DAAN_DOING_TESTS" value="true"/>
+	</php>
+	<testsuites>
+		<testsuite name="default">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+	<coverage cacheDirectory=".phpunit.cache/code-coverage"
+			  processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+	</coverage>
 </phpunit>

--- a/src/Admin/Messages.php
+++ b/src/Admin/Messages.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plausible Analytics | Admin Actions.
+ *
  * @since      2.0.6
  * @package    WordPress
  * @subpackage Plausible Analytics
@@ -14,6 +15,26 @@ defined( 'ABSPATH' ) || exit;
  * This class provides an alternative to the JS/Client approach to display error/notice messages in the Admin interface.
  */
 class Messages {
+	const ERROR_TRANSIENT      = 'plausible_analytics_error';
+
+	const NOTICE_TRANSIENT     = 'plausible_analytics_notice';
+
+	const SUCCESS_TRANSIENT    = 'plausible_analytics_success';
+
+	const ADDITIONAL_TRANSIENT = 'plausible_analytics_additional';
+
+	/**
+	 * Sets a success message.
+	 *
+	 * @param $message
+	 * @param $expiration
+	 *
+	 * @return void
+	 */
+	public static function set_success( $message, $expiration = 5 ) {
+		set_transient( self::SUCCESS_TRANSIENT, $message, $expiration );
+	}
+
 	/**
 	 * Sets an error.
 	 *
@@ -23,7 +44,7 @@ class Messages {
 	 * @return void
 	 */
 	public static function set_error( $message, $expiration = 5 ) {
-		set_transient( 'plausible_analytics_error', $message, $expiration );
+		set_transient( self::ERROR_TRANSIENT, $message, $expiration );
 	}
 
 	/**
@@ -35,6 +56,19 @@ class Messages {
 	 * @return void
 	 */
 	public static function set_notice( $message, $expiration = 5 ) {
-		set_transient( 'plausible_analytics_notice', $message, $expiration );
+		set_transient( self::NOTICE_TRANSIENT, $message, $expiration );
+	}
+
+	/**
+	 * Sets an additional message.
+	 *
+	 * @param string $message    The message to be displayed.
+	 * @param string $id         ID of the option where this additional message should be displayed.
+	 * @param int    $expiration Expiration in seconds.
+	 *
+	 * @return void
+	 */
+	public static function set_additional( $message, $id, $expiration = 5 ) {
+		set_transient( self::ADDITIONAL_TRANSIENT, [ $id => $message ], $expiration );
 	}
 }

--- a/src/Admin/Provisioning.php
+++ b/src/Admin/Provisioning.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plausible Analytics | Provisioning.
+ *
  * @since      2.0.0
  * @package    WordPress
  * @subpackage Plausible Analytics
@@ -56,6 +57,7 @@ class Provisioning {
 
 	/**
 	 * Action & filter hooks.
+	 *
 	 * @return void
 	 * @throws ApiException
 	 */
@@ -72,6 +74,7 @@ class Provisioning {
 
 	/**
 	 * Show an error on the settings screen if cURL isn't enabled on this machine.
+	 *
 	 * @return void
 	 */
 	public function add_curl_error() {

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -472,7 +472,7 @@ class API {
 					'class' => '' === $current_tab ? 'font-bold' : '',
 				],
 				'self-hosted' => [
-					'name'  => esc_html__( 'Self-Hosted', 'plausible-analytics' ),
+					'name'  => esc_html__( 'Community Edition', 'plausible-analytics' ),
 					'url'   => admin_url( 'options-general.php?page=plausible_analytics&tab=self-hosted' ),
 					'class' => 'self-hosted' === $current_tab ? 'font-bold' : '',
 				],

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -51,7 +51,7 @@ class API {
 		wp_nonce_field( 'plausible_analytics_toggle_option' );
 
 		$settings        = Helpers::get_settings();
-		$followed_wizard = get_option( 'plausible_analytics_wizard_done' );
+		$followed_wizard = get_option( 'plausible_analytics_wizard_done' ) || ! empty( $settings[ 'self_hosted_domain' ] );
 
 		/**
 		 * On-boarding wizard.
@@ -504,6 +504,9 @@ class API {
 		?>
 		<?php if ( ! empty( $quick_actions ) && count( $quick_actions ) > 0 ) : ?>
 			<?php foreach ( $quick_actions as $quick_action ) : ?>
+				<?php if ( ! empty( $quick_action[ 'disabled' ] ) && $quick_action[ 'disabled' ] === true ) : ?>
+					<?php continue; ?>
+				<?php endif; ?>
 				<a id="<?php echo $quick_action[ 'id' ]; ?>" class="no-underline text-sm leading-6 text-gray-900"
 				   target="<?php echo $quick_action[ 'target' ]; ?>" href="<?php echo $quick_action[ 'url' ]; ?>"
 				   title="<?php echo $quick_action[ 'label' ]; ?>" data-nonce="<?php echo $quick_action[ 'nonce' ]; ?>">
@@ -522,13 +525,16 @@ class API {
 	 * @return array
 	 */
 	private function get_quick_actions() {
+		$settings = Helpers::get_settings();
+
 		return [
 			'getting-started' => [
-				'label'  => esc_html__( 'Getting Started Guide', 'plausible-analytics' ),
-				'url'    => '#',
-				'id'     => 'show_wizard',
-				'target' => '_self',
-				'nonce'  => wp_create_nonce( 'plausible_analytics_show_wizard' ),
+				'label'    => esc_html__( 'Getting Started Guide', 'plausible-analytics' ),
+				'url'      => '#',
+				'id'       => 'show_wizard',
+				'target'   => '_self',
+				'nonce'    => wp_create_nonce( 'plausible_analytics_show_wizard' ),
+				'disabled' => ! empty( $settings[ 'self_hosted_domain' ] ),
 			],
 			'view-docs'       => [
 				'label'  => esc_html__( 'Documentation', 'plausible-analytics' ),

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -377,23 +377,17 @@ class API {
 	 * @return void
 	 */
 	private function render_notices_field() {
-		/**
-		 * If this var contains a value, the notice box will be shown on next pageloads until the transient is expired.
-		 */
-		$show_error  = get_transient( 'plausible_analytics_error' );
-		$show_notice = get_transient( 'plausible_analytics_notice' );
 		?>
 		<!-- notices -->
 		<div
 			class="z-50 fixed inset-0 top-5 flex items-end justify-center px-6 py-8 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
 			<div id="plausible-analytics-notice"
-				 class="<?php echo $show_error || $show_notice ? '' :
-					 'hidden'; ?> max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto transition-opacity ease-in-out duration-200 <?php echo $show_error ||
-				 $show_notice ? 'opacity-100' : 'opacity-0'; ?>">
+				 class="hidden max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto transition-opacity ease-in-out duration-200 opacity-0">
 				<div class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
 					<div class="p-4">
 						<div class="flex items-start">
-							<div id="icon-success" class="flex-shrink-0 <?php echo $show_error || $show_notice ? 'hidden' : ''; ?>">
+							<!-- Success -->
+							<div id="icon-success" class="flex-shrink-0 hidden">
 								<svg class="h-8 w-6 text-green-400" xmlns="http://www.w3.org/2000/svg" fill="none"
 									 viewBox="0 0 24 24"
 									 stroke="currentColor">
@@ -401,26 +395,25 @@ class API {
 										  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
 								</svg>
 							</div>
-							<div id="icon-error" class="flex-shrink-0 <?php echo $show_error ? '' : 'hidden'; ?>">
+							<!-- Error -->
+							<div id="icon-error" class="flex-shrink-0 hidden">
 								<svg class="h-8 w-6 text-red-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
 									 stroke-width="2" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round"
 										  d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
 								</svg>
 							</div>
-							<div id="icon-notice" class="flex-shrink-0 <?php echo $show_notice ? '' : 'hidden'; ?>">
+							<!-- Warning -->
+							<div id="icon-notice" class="flex-shrink-0 hidden">
 								<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
 									 class="w-6 h-8 text-yellow-400">
 									<path stroke-linecap="round" stroke-linejoin="round"
 										  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/>
 								</svg>
-
 							</div>
 							<div class="ml-3 w-0 flex-1 pt-0.5">
-								<! -- message -->
-								<p id="plausible-analytics-notice-text" class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
-									<?php echo $show_error ?: $show_notice ?: ''; ?>
-								</p>
+								<!-- message -->
+								<p id="plausible-analytics-notice-text" class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200"></p>
 							</div>
 						</div>
 					</div>

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -515,7 +515,7 @@ class API {
 				<?php endif; ?>
 				<a id="<?php echo $quick_action[ 'id' ]; ?>" class="no-underline text-sm leading-6 text-gray-900"
 				   target="<?php echo $quick_action[ 'target' ]; ?>" href="<?php echo $quick_action[ 'url' ]; ?>"
-				   title="<?php echo $quick_action[ 'label' ]; ?>" data-nonce="<?php echo $quick_action[ 'nonce' ]; ?>">
+				   title="<?php echo $quick_action[ 'label' ]; ?>">
 					<?php echo $quick_action[ 'label' ]; ?>
 				</a>
 			<?php endforeach; ?>
@@ -532,14 +532,14 @@ class API {
 	 */
 	private function get_quick_actions() {
 		$settings = Helpers::get_settings();
+		$nonce    = wp_create_nonce( 'plausible_analytics_show_wizard' );
 
 		return [
 			'getting-started' => [
 				'label'    => esc_html__( 'Getting Started Guide', 'plausible-analytics' ),
-				'url'      => '#',
+				'url'      => admin_url( "admin-ajax.php?action=plausible_analytics_show_wizard&_nonce=$nonce&redirect=1" ),
 				'id'       => 'show_wizard',
 				'target'   => '_self',
-				'nonce'    => wp_create_nonce( 'plausible_analytics_show_wizard' ),
 				'disabled' => ! empty( $settings[ 'self_hosted_domain' ] ),
 			],
 			'view-docs'       => [
@@ -547,14 +547,12 @@ class API {
 				'url'    => esc_url( 'https://plausible.io/docs' ),
 				'id'     => '',
 				'target' => '_blank',
-				'nonce'  => '',
 			],
 			'report-issue'    => [
 				'label'  => esc_html__( 'Contact Support', 'plausible-analytics' ),
 				'url'    => esc_url( 'https://plausible.io/contact' ),
 				'id'     => '',
 				'target' => '_blank',
-				'nonce'  => '',
 			],
 		];
 	}

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -277,6 +277,12 @@ class API {
 												   class="hover:cursor-pointer inline-block mt-4 px-4 py-2 border no-underline text-sm leading-5 font-medium rounded-md text-red-700 bg-white dark:text-white hover:text-red-500 dark:hover:text-red-400 focus:outline-none focus:border-blue-300 focus:ring active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150">
 													<?php esc_html_e( 'Setup later', 'plausible-analytics' ); ?>
 												</a>
+												<a href="<?php echo admin_url(
+													"admin-ajax.php?action=plausible_analytics_quit_wizard&_nonce=$nonce&redirect=self-hosted"
+												); ?>"
+												   class="float-right hover:cursor-pointer inline-block mt-4 px-4 py-2 border no-underline text-sm leading-5 font-medium rounded-md text-red-700 bg-white dark:text-white hover:text-red-500 dark:hover:text-red-400 focus:outline-none focus:border-blue-300 focus:ring active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150">
+													<?php esc_html_e( 'Community Edition', 'plausible-analytics' ); ?>
+												</a>
 											<?php else: ?>
 												<a href="<?php echo admin_url(
 													"admin-ajax.php?action=plausible_analytics_quit_wizard&_nonce=$nonce&redirect=1"

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -680,7 +680,7 @@ class API {
 				( is_array( $slug ) ? checked( $value, in_array( $value, $slug, false ) ? $value : false, false ) : checked( $value, $slug, false ) );
 		$disabled = ! empty( $field[ 'disabled' ] ) ? 'disabled' : '';
 		?>
-		<div class="flex items-center mt-4 space-x-3">
+		<div class="toggle-container flex items-center mt-4 space-x-3">
 			<button
 				class="plausible-analytics-toggle <?php echo $checked && ! $disabled ? 'bg-indigo-600' :
 					'bg-gray-200'; ?> dark:bg-gray-700 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring"
@@ -759,7 +759,7 @@ class API {
 
 		ob_start();
 		?>
-		<div class="">
+		<div class="plausible-analytics-hook transition-opacity transition-300">
 			<div class="rounded-md p-4 mt-4 relative <?php echo esc_attr( $box_class ); ?> rounded-t-md rounded-b-none">
 				<div class="flex">
 					<div class="flex-shrink-0">

--- a/src/Admin/Settings/Hooks.php
+++ b/src/Admin/Settings/Hooks.php
@@ -29,8 +29,6 @@ class Hooks extends API {
 	 * @return void
 	 */
 	private function init_hooks() {
-		add_action( 'plausible_analytics_toggle_option_message', [ $this, 'maybe_modify_option_message' ], 9, 3 );
-		add_action( 'plausible_analytics_toggle_option_message', [ $this, 'maybe_render_additional_message' ], 10, 3 );
 		add_action( 'plausible_analytics_settings_api_connect_button', [ $this, 'connect_button' ] );
 		add_action( 'plausible_analytics_settings_api_token_missing', [ $this, 'missing_api_token_warning' ] );
 		add_action( 'plausible_analytics_settings_option_not_available_in_ce', [ $this, 'option_na_in_ce' ] );
@@ -38,59 +36,6 @@ class Hooks extends API {
 		add_action( 'plausible_analytics_settings_enable_analytics_dashboard_notice', [ $this, 'enable_analytics_dashboard_notice' ] );
 		add_action( 'plausible_analytics_settings_option_disabled_by_missing_api_token', [ $this, 'option_disabled_by_missing_api_token' ] );
 		add_action( 'plausible_analytics_settings_option_disabled_by_proxy', [ $this, 'option_disabled_by_proxy' ] );
-	}
-
-	/**
-	 * We modify the response message here, because otherwise the response to enabling the Proxy option would be "Enable proxy enabled." Sounds
-	 * weird, doesn't it?
-	 *
-	 * @param $response
-	 * @param $option_name
-	 * @param $toggle_status
-	 *
-	 * @return mixed
-	 */
-	public function maybe_modify_option_message( $response, $option_name, $toggle_status ) {
-		if ( $option_name === 'proxy_enabled' ) {
-			$response[ 'message' ] = __( 'Proxy enabled.', 'plausible-analytics' );
-
-			if ( ! $toggle_status ) {
-				$response[ 'message' ] = __( 'Proxy disabled.', 'plausible-analytics' );
-			}
-		}
-
-		return $response;
-	}
-
-	/**
-	 * Adds the 'additional' array element to $message if applicable.
-	 *
-	 * @param $response
-	 * @param $option_name
-	 * @param $toggle_status
-	 *
-	 * @return array
-	 */
-	public function maybe_render_additional_message( $response, $option_name, $toggle_status ) {
-		if ( ! $toggle_status ) {
-			return $response;
-		}
-
-		$additional_message_html = '';
-
-		if ( $option_name === 'proxy_enabled' ) {
-			$additional_message_html = $this->render_hook_field( Page::PROXY_WARNING_HOOK );
-		}
-
-		if ( $option_name === 'enable_analytics_dashboard' ) {
-			$additional_message_html = $this->render_hook_field( Page::ENABLE_ANALYTICS_DASH_NOTICE );
-		}
-
-		if ( ! $additional_message_html ) {
-			return $response;
-		}
-
-		return array_merge( $response, [ 'additional' => $additional_message_html ] );
 	}
 
 	/**

--- a/src/Admin/Settings/Hooks.php
+++ b/src/Admin/Settings/Hooks.php
@@ -19,8 +19,10 @@ class Hooks extends API {
 	/**
 	 * Build class properties.
 	 */
-	public function __construct() {
-		$this->init_hooks();
+	public function __construct( $init = true ) {
+		if ( $init ) {
+			$this->init_hooks();
+		}
 	}
 
 	/**

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -345,6 +345,9 @@ class Page extends API {
 			],
 		];
 
+		/**
+		 * If self-hosted domain setting has a value, add option disabled notice to Ecommerce revenue toggle.
+		 */
 		if ( ! empty( $settings[ 'self_hosted_domain' ] ) ) {
 			$option_disabled_hook = [
 				[
@@ -354,12 +357,6 @@ class Page extends API {
 				],
 			];
 
-			$fields = $this->fields[ 'general' ][ 0 ][ 'fields' ];
-
-			array_splice( $fields, 2, 0, $option_disabled_hook );
-
-			$this->fields[ 'general' ][ 0 ][ 'fields' ] = $fields;
-
 			$fields = $this->fields[ 'general' ][ 1 ][ 'fields' ];
 
 			array_splice( $fields, 5, 0, $option_disabled_hook );
@@ -367,6 +364,11 @@ class Page extends API {
 			$this->fields[ 'general' ][ 1 ][ 'fields' ] = $fields;
 		}
 
+		/**
+		 * If proxy is enabled, or self-hosted domain has a value, display warning box.
+		 *
+		 * @see self::proxy_warning()
+		 */
 		if ( Helpers::proxy_enabled() || ! empty( $settings[ 'self_hosted_domain' ] ) ) {
 			$this->fields[ 'general' ][ 2 ][ 'fields' ][] = [
 				'label' => '',

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -352,7 +352,7 @@ class Page extends API {
 			$option_disabled_hook = [
 				[
 					'label' => '',
-					'slug'  => 'option_disabled_by_self_hosted_domain',
+					'slug'  => 'option_not_available_in_ce',
 					'type'  => 'hook',
 				],
 			];
@@ -437,7 +437,7 @@ class Page extends API {
 		 */
 		add_action( 'plausible_analytics_settings_api_connect_button', [ $this, 'connect_button' ] );
 		add_action( 'plausible_analytics_settings_api_token_missing', [ $this, 'api_token_missing' ] );
-		add_action( 'plausible_analytics_settings_option_disabled_by_self_hosted_domain', [ $this, 'option_disabled_by_self_hosted_domain' ] );
+		add_action( 'plausible_analytics_settings_option_not_available_in_ce', [ $this, 'option_na_in_ce' ] );
 		add_action( 'plausible_analytics_settings_proxy_warning', [ $this, 'proxy_warning' ] );
 		add_action( 'plausible_analytics_settings_enable_analytics_dashboard_notice', [ $this, 'enable_analytics_dashboard_notice' ] );
 		add_action( 'plausible_analytics_settings_option_disabled_by_missing_api_token', [ $this, 'option_disabled_by_missing_api_token' ] );
@@ -715,7 +715,7 @@ class Page extends API {
 	 */
 	public function proxy_warning() {
 		if ( ! empty( Helpers::get_settings()[ 'self_hosted_domain' ] ) ) {
-			$this->option_disabled_by_self_hosted_domain();
+			$this->option_na_in_ce();
 		} else {
 			echo sprintf(
 				wp_kses(
@@ -735,10 +735,10 @@ class Page extends API {
 	 *
 	 * @return void
 	 */
-	public function option_disabled_by_self_hosted_domain() {
+	public function option_na_in_ce() {
 		echo wp_kses(
 			__(
-				'This option is disabled, because a Self-Hosted <strong>Domain Name</strong> is entered.',
+				'This feature is not available in Plausible Community Edition.',
 				'plausible-analytics'
 			),
 			'post'

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -273,20 +273,20 @@ class Page extends API {
 			],
 			'self-hosted' => [
 				[
-					'label'  => esc_html__( 'Self-hosted Plausible Analytics', 'plausible-analytics' ),
+					'label'  => esc_html__( 'Plausible Community Edition', 'plausible-analytics' ),
 					'slug'   => 'is_self_hosted',
 					'type'   => 'group',
 					'desc'   => sprintf(
 						'%1$s <a href="%2$s" target="_blank">%3$s</a>',
 						wp_kses(
 							__(
-								'If you\'re self-hosting Plausible on your own infrastructure, enter the domain name where you installed it to enable the integration with your self-hosted instance. Multisites can use the <code>PLAUSIBLE_SELF_HOSTED_DOMAIN</code> constant to define the URL for all subsites at once.',
+								'If you\'re using Plausible Community Edition on your own infrastructure, enter the domain name where you installed it to enable the integration with your self-hosted instance. Multisites can use the <code>PLAUSIBLE_SELF_HOSTED_DOMAIN</code> constant to define the URL for all subsites at once.',
 								'plausible-analytics'
 							),
 							'post'
 						),
 						esc_url( 'https://plausible.io/self-hosted-web-analytics/' ),
-						esc_html__( 'Learn more about Plausible Self-Hosted.', 'plausible-analytics' )
+						esc_html__( 'Learn more about Plausible Community Edition.', 'plausible-analytics' )
 					),
 					'toggle' => '',
 					'fields' => [

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -236,7 +236,7 @@ class Ajax {
 		}
 
 		$additional_message_html = '';
-		$hooks                   = new Hooks();
+		$hooks                   = new Hooks( false );
 
 		if ( $option_name === 'proxy_enabled' ) {
 			$additional_message_html = $hooks->render_hook_field( Page::PROXY_WARNING_HOOK );

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -35,7 +35,7 @@ class Ajax {
 	}
 
 	/**
-	 * Mark the wizard as finished, so it won't appear again.
+	 * Mark the wizard as finished, so it won't appear again, and optionally redirect.
 	 *
 	 * @return void
 	 */
@@ -52,7 +52,9 @@ class Ajax {
 			$url = admin_url( 'options-general.php?page=plausible_analytics' );
 
 			// Redirect param points to a specific option.
-			if ( $request_data[ 'redirect' ] !== '1' ) {
+			if ( strpos( $request_data[ 'redirect' ], 'self-hosted' ) !== false ) {
+				$url .= '&tab=' . $request_data[ 'redirect' ];
+			} elseif ( $request_data[ 'redirect' ] !== '1' ) {
 				$url .= '#' . $request_data[ 'redirect' ];
 			}
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -10,6 +10,8 @@
 namespace Plausible\Analytics\WP;
 
 use Plausible\Analytics\WP\Admin\Messages;
+use Plausible\Analytics\WP\Admin\Settings\API;
+use Plausible\Analytics\WP\Admin\Settings\Page;
 use Plausible\Analytics\WP\Client\ApiException;
 
 defined( 'ABSPATH' ) || exit;
@@ -155,12 +157,23 @@ class Ajax {
 		// Update all the options to plausible settings.
 		update_option( 'plausible_analytics_settings', $settings );
 
-		do_action( 'plausible_analytics_settings_saved' );
+		/**
+		 * Allow devs to perform additional actions.
+		 */
+		do_action( 'plausible_analytics_settings_saved', $settings, $post_data[ 'option_name' ], $post_data[ 'toggle_status' ] );
 
 		$option_label  = $post_data[ 'option_label' ];
 		$toggle_status = $post_data[ 'toggle_status' ] === 'on' ? __( 'enabled', 'plausible-analytics' ) : __( 'disabled', 'plausible-analytics' );
+		$message       = apply_filters(
+			'plausible_analytics_toggle_option_message',
+			[
+				'message' => sprintf( '%s %s.', $option_label, $toggle_status ),
+			],
+			$post_data[ 'option_name' ],
+			$post_data[ 'toggle_status' ]
+		);
 
-		wp_send_json_success( sprintf( '%s %s.', $option_label, $toggle_status ), 200 );
+		wp_send_json_success( $message, 200 );
 	}
 
 	/**

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Plausible\Analytics\WP;
 
 use Exception;
+use Plausible\Analytics\WP\Admin\Messages;
 use Plausible\Analytics\WP\Client\ApiException;
 use Plausible\Analytics\WP\Client\Lib\GuzzleHttp\Client as GuzzleClient;
 use Plausible\Analytics\WP\Client\Api\DefaultApi;
@@ -158,9 +159,9 @@ class Client {
 
 		// Any error codes outside the 4xx range should show a generic error.
 		if ( $code <= 399 || $code >= 500 ) {
-			$message = __( 'Something went wrong, try again later.', 'plausible-analytics' );
+			Messages::set_error( __( 'Something went wrong, try again later.', 'plausible-analytics' ) );
 
-			wp_send_json_error( $message );
+			wp_send_json_error( null, $code );
 		}
 
 		$message       = $e->getMessage();
@@ -184,7 +185,9 @@ class Client {
 			}
 		}
 
-		wp_send_json_error( sprintf( $error_message, $message ) );
+		Messages::set_error( sprintf( $error_message, $message ) );
+
+		wp_send_json_error( null, $code );
 	}
 
 	/**


### PR DESCRIPTION
Instead of triggering a page reload after toggling some options (Proxy and View Stats) show the additional information immediately: 


https://github.com/plausible/wordpress/assets/18595395/489b94c8-a7a6-4f83-b69f-301d466d474f

