### PR TITLE
Rename API token to Plugin token

### DIFF
--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -618,7 +618,7 @@ class API {
 		?>
 		<div class="mt-4">
 			<label class="block text-sm font-medium leading-5 !text-gray-700 !dark:text-gray-300"
-				   for="<?php echo $field[ 'slug' ]; ?>"><?php echo esc_attr( $field[ 'label' ] ); ?></label>
+				   for="<?php echo $field[ 'slug' ]; ?>"><?php echo $field[ 'label' ]; ?></label>
 			<div class="mt-1">
 				<input
 					class="block w-full !border-gray-300 !dark:border-gray-700 !rounded-md focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-900 dark:text-gray-300 py-2 px-3"

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -62,7 +62,7 @@ class API {
 			$this->slides             = [
 				'welcome'                    => __( 'Welcome to Plausible Analytics', 'plausible-analytics' ),
 				'domain_name'                => __( 'Confirm domain', 'plausible-analytics' ),
-				'api_token'                  => __( 'Create API token', 'plausible-analytics' ),
+				'api_token'                  => __( 'Create Plugin Token', 'plausible-analytics' ),
 				'enable_analytics_dashboard' => __( 'View the stats in your WP dashboard', 'plausible-analytics' ),
 				'enhanced_measurements'      => __( 'Enhanced measurements', 'plausible-analytics' ),
 				'proxy_enabled'              => __( 'Enable proxy', 'plausible-analytics' ),
@@ -82,7 +82,7 @@ class API {
 					'plausible-analytics'
 				),
 				'api_token'                  => __(
-					'<a class="hover:cursor-pointer underline plausible-create-api-token">Create an API token</a> (link opens in a new window) that we\'ll use to automate your setup process. Paste the API token in the field below and click "Next".',
+					'<a class="hover:cursor-pointer underline plausible-create-api-token">Create a Plugin Token</a> (link opens in a new window) that we\'ll use to automate your setup process. Paste the Plugin Token in the field below and click "Next".',
 					'plausible-analytics'
 				),
 				'enable_analytics_dashboard' => __(
@@ -135,11 +135,11 @@ class API {
 						'plausible-analytics'
 					),
 					__(
-						'For instance, after inserting the API token, enable the new Authors and categories tracking and it will be displayed in your stats immediately without you needing to add those properties manually in your site settings.',
+						'For instance, after inserting the Plugin Token, enable the new Authors and categories tracking and it will be displayed in your stats immediately without you needing to add those properties manually in your site settings.',
 						'plausible-analytics'
 					),
 					__(
-						'This welcome screen will guide you through the process of creating the API token and introduce you to other new features we\'ve added, e.g. Revenue tracking. Click on the “Next” button below to start.',
+						'This welcome screen will guide you through the process of creating the Plugin Token and introduce you to other new features we\'ve added, e.g. Revenue tracking. Click on the “Next” button below to start.',
 						'plausible-analytics'
 					),
 					__( 'We hope you’ll find this useful. Thanks again for using Plausible!', 'plausible-analytics' )

--- a/src/Admin/Settings/Hooks.php
+++ b/src/Admin/Settings/Hooks.php
@@ -108,7 +108,7 @@ class Hooks extends API {
 	}
 
 	/**
-	 * Show notice when API token notice is disabled.
+	 * Show notice when Plugin Token notice is disabled.
 	 *
 	 * @output HTML
 	 */
@@ -162,7 +162,7 @@ class Hooks extends API {
 	}
 
 	/**
-	 * Display missing API token warning.
+	 * Display missing Plugin Token warning.
 	 *
 	 * @output HTML
 	 */
@@ -170,7 +170,7 @@ class Hooks extends API {
 		echo sprintf(
 			wp_kses(
 				__(
-					'Please <a class="plausible-create-api-token hover:cursor-pointer underline">create an API token</a> and insert it into the API token field above.',
+					'Please <a class="plausible-create-api-token hover:cursor-pointer underline">create a Plugin Token</a> and insert it into the Plugin Token field above.',
 					'plausible-analytics'
 				),
 				'post'
@@ -179,14 +179,14 @@ class Hooks extends API {
 	}
 
 	/**
-	 * Display option disabled by missing API token warning.
+	 * Display option disabled by missing Plugin Token warning.
 	 *
 	 * @output HTML
 	 */
 	public function option_disabled_by_missing_api_token() {
 		echo wp_kses(
 			__(
-				'Please <a class="plausible-create-api-token hover:cursor-pointer underline">create an API token</a> and insert it into the API token field above to enable this option.',
+				'Please <a class="plausible-create-api-token hover:cursor-pointer underline">create a Plugin Token</a> and insert it into the Plugin Token field above to enable this option.',
 				'plausible-analytics'
 			),
 			'post'

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -80,7 +80,7 @@ class Page extends API {
 					'desc'   => sprintf(
 						wp_kses(
 							__(
-								'Ensure your domain name matches the one in <a href="%s" target="_blank">your Plausible account</a>, then <a class="hover:cursor-pointer underline plausible-create-api-token">create an API token</a> (link opens in a new window) and paste it into the \'API token\' field.',
+								'Ensure your domain name matches the one in <a href="%s" target="_blank">your Plausible account</a>, then <a class="hover:cursor-pointer underline plausible-create-api-token">create a Plugin Token</a> (link opens in a new window) and paste it into the \'Plugin Token\' field.',
 								'plausible-analytics'
 							),
 							'post'
@@ -95,7 +95,7 @@ class Page extends API {
 							'value' => Helpers::get_domain(),
 						],
 						[
-							'label' => esc_html__( 'API token', 'plausible-analytics' ),
+							'label' => esc_html__( 'Plugin Token', 'plausible-analytics' ),
 							'slug'  => 'api_token',
 							'type'  => 'text',
 							'value' => $settings[ 'api_token' ],
@@ -413,7 +413,7 @@ class Page extends API {
 		}
 
 		/**
-		 * No API token is entered.
+		 * No Plugin Token is entered.
 		 */
 		if ( empty( $settings[ 'api_token' ] ) ) {
 			$this->fields[ 'general' ][ 0 ][ 'fields' ][] = self::API_TOKEN_MISSING_HOOK;

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -95,7 +95,11 @@ class Page extends API {
 							'value' => Helpers::get_domain(),
 						],
 						[
-							'label' => esc_html__( 'Plugin Token', 'plausible-analytics' ),
+							'label' => esc_html__( 'Plugin Token', 'plausible-analytics' ) .
+								' - ' .
+								'<a class="hover:cursor-pointer underline plausible-create-api-token">' .
+								__( 'Create Token', 'plausible-analytics' ) .
+								'</a>',
 							'slug'  => 'api_token',
 							'type'  => 'text',
 							'value' => $settings[ 'api_token' ],

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -284,7 +284,7 @@ class Ajax {
 			// Clean spaces
 			$settings[ $option->name ] = trim( $option->value );
 
-			// Validate API token, if this is the API token field.
+			// Validate Plugin Token, if this is the Plugin Token field.
 			if ( $option->name === 'api_token' ) {
 				$this->validate_api_token( $option->value );
 			}
@@ -298,7 +298,7 @@ class Ajax {
 	}
 
 	/**
-	 * Validate the entered API token, before storing it to the DB. wp_send_json_error() ensures that code execution stops.
+	 * Validate the entered Plugin Token, before storing it to the DB. wp_send_json_error() ensures that code execution stops.
 	 *
 	 * @param string $token
 	 *
@@ -311,7 +311,7 @@ class Ajax {
 		if ( ! $client->validate_api_token() ) {
 			Messages::set_error(
 				__(
-					'Oops! The API token you used is invalid. Please <a class="plausible-create-api-token hover:cursor-pointer underline">click here</a> to generate a new token.',
+					'Oops! The Plugin Token you used is invalid. Please <a class="plausible-create-api-token hover:cursor-pointer underline">click here</a> to generate a new token.',
 					'plausible-analytics'
 				)
 			);

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -310,9 +310,12 @@ class Ajax {
 
 		if ( ! $client->validate_api_token() ) {
 			Messages::set_error(
-				__(
-					'Oops! The Plugin Token you used is invalid. Please <a class="plausible-create-api-token hover:cursor-pointer underline">click here</a> to generate a new token.',
-					'plausible-analytics'
+				sprintf(
+					__(
+						'Oops! The Plugin Token you used is invalid. Please <a class="plausible-create-api-token hover:cursor-pointer underline">click here</a> to generate a new token. <a target="_blank" href="%s">Read more</a>',
+						'plausible-analytics'
+					),
+					'https://plausible.io/wordpress-analytics-plugin#oops-the-token-you-used-is-invalid'
 				)
 			);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,7 +40,7 @@ class Client {
 	}
 
 	/**
-	 * Validates the API token (password) set in the current instance and caches the state to a transient valid for 1 day.
+	 * Validates the Plugin Token (password) set in the current instance and caches the state to a transient valid for 1 day.
 	 *
 	 * @return bool
 	 * @throws ApiException
@@ -83,7 +83,7 @@ class Client {
 	}
 
 	/**
-	 * Retrieve all capabilities assigned to configured API token.
+	 * Retrieve all capabilities assigned to configured Plugin Token.
 	 *
 	 * @return bool|Client\Model\Capabilities
 	 *


### PR DESCRIPTION
It also adds a informational link to the Invalid API token error message, and adds a "Create Token" field next to the label of the Plugin Token settings field.

![image](https://github.com/plausible/wordpress/assets/18595395/749fedbc-7337-4e38-b105-e24d291e7b46)

![image](https://github.com/plausible/wordpress/assets/18595395/f271813a-2879-4efb-9a26-d2ee8c087f4f)

![image](https://github.com/plausible/wordpress/assets/18595395/82eb579e-5727-4544-8843-d36a0626d69f)

![image](https://github.com/plausible/wordpress/assets/18595395/f8151ec3-107e-4ae6-9ee5-c04a9b7317a1)
