### PR TITLE
Fixed: HTML would break if taxonomy name contained apostrophies.

### DIFF
--- a/src/Filters.php
+++ b/src/Filters.php
@@ -112,7 +112,7 @@ class Filters {
 			// Loop through the terms.
 			foreach ( $terms as $term ) {
 				if ( $term instanceof WP_Term ) {
-					$params .= " event-{$taxonomy}='{$term->name}'";
+					$params .= " event-{$taxonomy}=\"{$term->name}\"";
 				}
 			}
 		}

--- a/tests/integration/Integrations/WooCommerceTest.php
+++ b/tests/integration/Integrations/WooCommerceTest.php
@@ -5,10 +5,12 @@
 
 namespace Plausible\Analytics\Tests\Integration;
 
+use AllowDynamicProperties;
 use Plausible\Analytics\Tests\TestCase;
 use Plausible\Analytics\WP\Integrations\WooCommerce;
 use function Brain\Monkey\Functions\when;
 
+#[AllowDynamicProperties]
 class WooCommerceTest extends TestCase {
 	/**
 	 * @see WooCommerce::track_entered_checkout()

--- a/tests/integration/Integrations/WooCommerceTest.php
+++ b/tests/integration/Integrations/WooCommerceTest.php
@@ -65,7 +65,7 @@ class WooCommerceTest extends TestCase {
 
 		when( 'wc_get_order' )->justReturn( $mock );
 
-		$this->expectOutputContains( '{"revenue":{"amount":"10.00","currency":"EUR"}}' );
+		$this->expectOutputContains( '{"revenue":{"amount":"10","currency":"EUR"}}' );
 
 		$class->track_purchase( 1 );
 	}


### PR DESCRIPTION
Fixes this issue reported on WP.org: https://wordpress.org/support/topic/apostrophe-in-category-name-may-affect-script/
