### PR TITLE
Fix #4542 - Fix 404 Tracking

### DIFF
--- a/src/Actions.php
+++ b/src/Actions.php
@@ -71,10 +71,15 @@ class Actions {
 			$data = wp_json_encode(
 				[
 					'props' => [
-						'path' => 'documentation.location.pathname',
+						'path' => 'document.location.pathname',
 					],
 				]
 			);
+
+			/**
+			 * Documentation.location.pathname is a variable. @see wp_json_encode() doesn't allow passing variable, only strings. This fixes that.
+			 */
+			$data = str_replace( '"document.location.pathname"', 'document.location.pathname', $data );
 
 			wp_add_inline_script(
 				'plausible-analytics',

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -112,7 +112,7 @@ class Filters {
 			// Loop through the terms.
 			foreach ( $terms as $term ) {
 				if ( $term instanceof WP_Term ) {
-					$params .= " event-{$taxonomy}='{$term->name}'";
+					$params .= " event-{$taxonomy}=\"{$term->name}\"";
 				}
 			}
 		}

--- a/tests/integration/Integrations/WooCommerceTest.php
+++ b/tests/integration/Integrations/WooCommerceTest.php
@@ -5,10 +5,12 @@
 
 namespace Plausible\Analytics\Tests\Integration;
 
+use AllowDynamicProperties;
 use Plausible\Analytics\Tests\TestCase;
 use Plausible\Analytics\WP\Integrations\WooCommerce;
 use function Brain\Monkey\Functions\when;
 
+#[AllowDynamicProperties]
 class WooCommerceTest extends TestCase {
 	/**
 	 * @see WooCommerce::track_entered_checkout()

--- a/tests/integration/Integrations/WooCommerceTest.php
+++ b/tests/integration/Integrations/WooCommerceTest.php
@@ -65,7 +65,7 @@ class WooCommerceTest extends TestCase {
 
 		when( 'wc_get_order' )->justReturn( $mock );
 
-		$this->expectOutputContains( '{"revenue":{"amount":"10.00","currency":"EUR"}}' );
+		$this->expectOutputContains( '{"revenue":{"amount":"10","currency":"EUR"}}' );
 
 		$class->track_purchase( 1 );
 	}


### PR DESCRIPTION
The issue was two-fold:

- There was a typo ("`documentation`" instead of "`document`")
- `wp_json_encode()` converted it to a string, which makes sense, instead of using it as a variable.