### PR TITLE
Track form submissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,6 +40,9 @@ jobs:
           --health-retries 10
 
     steps:
+      - name: Install SVN
+      - run: sudo apt-get install -y subversion
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Install SVN
-      - run: sudo apt-get install -y subversion
+        run: sudo apt-get install -y subversion
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/assets/src/js/integrations/form-submit.js
+++ b/assets/src/js/integrations/form-submit.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		 * Send a custom event to Plausible.
 		 */
 		trackSubmission: function () {
-			plausible('Form Submission', {'props': {'form': document.location.pathname}});
+			plausible(plausible_analytics_i18n.form_completions, {'props': {'form': document.location.pathname}});
 		}
 	};
 

--- a/assets/src/js/integrations/form-submit.js
+++ b/assets/src/js/integrations/form-submit.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			let self = this;
 
 			this.forms.forEach((form) => {
-				form.addEventListener('submit', function (e) {
+				form.addEventListener('submit', (e) => {
 					if (self.isValid(e.target)) {
 						self.trackSubmission();
 					}

--- a/assets/src/js/integrations/form-submit.js
+++ b/assets/src/js/integrations/form-submit.js
@@ -22,55 +22,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			this.forms.forEach((form) => {
 				form.addEventListener('submit', (e) => {
-					if (self.isValid(e.target)) {
+					if (e.target.checkValidity()) {
 						self.trackSubmission();
 					}
 				})
 			})
-		},
-
-		/**
-		 * Runs basic validation on the form.
-		 *
-		 * @param form
-		 * @returns {boolean}
-		 */
-		isValid: function (form) {
-			let self = this;
-			let valid = true;
-
-			Array.from(form).some((element) => {
-				if (self.isInput(element)) {
-					if ((element.tagName === 'INPUT' || element.tagName === 'TEXTAREA') && element.required === true && element.value === '') {
-						valid = false;
-
-						return;
-					}
-
-					/**
-					 * A known caveat in this check is, that if the first option in the SELECT is e.g. "Please make a choice", it will still pass as valid.
-					 */
-					if (element.tagName === 'SELECT' && element.required === true && element.selectedIndex < 0) {
-						valid = false;
-
-						return;
-					}
-				}
-			});
-
-			return valid;
-		},
-
-		/**
-		 * Is element an input field?
-		 *
-		 * @param element
-		 * @returns {boolean}
-		 */
-		isInput: function (element) {
-			let inputs = ['INPUT', 'SELECT', 'TEXTAREA'];
-
-			return inputs.includes(element.tagName);
 		},
 
 		/**

--- a/assets/src/js/integrations/form-submit.js
+++ b/assets/src/js/integrations/form-submit.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		 * Send a custom event to Plausible.
 		 */
 		trackSubmission: function () {
-			console.log('trackSubmission');
+			plausible('Form Submission', {'props': {'form': document.location.pathname}});
 		}
 	};
 

--- a/assets/src/js/integrations/form-submit.js
+++ b/assets/src/js/integrations/form-submit.js
@@ -1,0 +1,85 @@
+/**
+ * Plausible Analytics
+ *
+ * Track Form Submissions JS
+ */
+document.addEventListener('DOMContentLoaded', () => {
+	let plausible_track_form_submit = {
+		forms: document.querySelectorAll('form'),
+
+		/**
+		 * Initialization.
+		 */
+		init: function () {
+			this.bindEvents();
+		},
+
+		/**
+		 * Bind Events.
+		 */
+		bindEvents: function () {
+			let self = this;
+
+			this.forms.forEach((form) => {
+				form.addEventListener('submit', function (e) {
+					if (self.isValid(e.target)) {
+						self.trackSubmission();
+					}
+				})
+			})
+		},
+
+		/**
+		 * Runs basic validation on the form.
+		 *
+		 * @param form
+		 * @returns {boolean}
+		 */
+		isValid: function (form) {
+			let self = this;
+			let valid = true;
+
+			Array.from(form).some((element) => {
+				if (self.isInput(element)) {
+					if ((element.tagName === 'INPUT' || element.tagName === 'TEXTAREA') && element.required === true && element.value === '') {
+						valid = false;
+
+						return;
+					}
+
+					/**
+					 * A known caveat in this check is, that if the first option in the SELECT is e.g. "Please make a choice", it will still pass as valid.
+					 */
+					if (element.tagName === 'SELECT' && element.required === true && element.selectedIndex < 0) {
+						valid = false;
+
+						return;
+					}
+				}
+			});
+
+			return valid;
+		},
+
+		/**
+		 * Is element an input field?
+		 *
+		 * @param element
+		 * @returns {boolean}
+		 */
+		isInput: function (element) {
+			let inputs = ['INPUT', 'SELECT', 'TEXTAREA'];
+
+			return inputs.includes(element.tagName);
+		},
+
+		/**
+		 * Send a custom event to Plausible.
+		 */
+		trackSubmission: function () {
+			console.log('trackSubmission');
+		}
+	};
+
+	plausible_track_form_submit.init();
+});

--- a/src/Actions.php
+++ b/src/Actions.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Plausible Analytics | Actions.
- *
  * @since      1.0.0
  * @package    WordPress
  * @subpackage Plausible Analytics
@@ -12,7 +11,6 @@ namespace Plausible\Analytics\WP;
 class Actions {
 	/**
 	 * Constructor.
-	 *
 	 * @since  1.0.0
 	 * @access public
 	 * @return void
@@ -24,9 +22,8 @@ class Actions {
 	}
 
 	/**
-	 * This <meta> tag "tells" the Plausible API which version of the plugin is used, to allow tailored error messages, specific to the plugin
-	 * version.
-	 *
+	 * This <meta> tag "tells" the Plausible API which version of the plugin is used, to allow tailored error messages,
+	 * specific to the plugin version.
 	 * @return void
 	 */
 	public function insert_version_meta_tag() {
@@ -37,7 +34,6 @@ class Actions {
 
 	/**
 	 * Register Assets.
-	 *
 	 * @since  1.0.0
 	 * @access public
 	 * @return void
@@ -56,9 +52,16 @@ class Actions {
 		}
 
 		$version =
-			Helpers::proxy_enabled() && file_exists( Helpers::get_js_path() ) ? filemtime( Helpers::get_js_path() ) : PLAUSIBLE_ANALYTICS_VERSION;
+			Helpers::proxy_enabled() && file_exists( Helpers::get_js_path() ) ? filemtime( Helpers::get_js_path() ) :
+				PLAUSIBLE_ANALYTICS_VERSION;
 
-		wp_enqueue_script( 'plausible-analytics', Helpers::get_js_url( true ), '', $version, apply_filters( 'plausible_load_js_in_footer', false ) );
+		wp_enqueue_script(
+			'plausible-analytics',
+			Helpers::get_js_url( true ),
+			'',
+			$version,
+			apply_filters( 'plausible_load_js_in_footer', false )
+		);
 
 		// Goal tracking inline script (Don't disable this as it is required by 404).
 		wp_add_inline_script(
@@ -77,7 +80,7 @@ class Actions {
 			);
 
 			/**
-			 * Documentation.location.pathname is a variable. @see wp_json_encode() doesn't allow passing variable, only strings. This fixes that.
+			 * document.location.pathname is a variable. @see wp_json_encode() doesn't allow passing variable, only strings. This fixes that.
 			 */
 			$data = str_replace( '"document.location.pathname"', 'document.location.pathname', $data );
 
@@ -95,14 +98,17 @@ class Actions {
 				[
 					'props' => [
 						// convert queries to lowercase and remove trailing whitespace to ensure same terms are grouped together
-						'search_query' => strtolower(trim(get_search_query())),
+						'search_query' => strtolower( trim( get_search_query() ) ),
 						'result_count' => $wp_query->found_posts,
 					],
 				]
 			);
 			$script = "plausible('WP Search Queries', $data );";
 
-			wp_add_inline_script( 'plausible-analytics', "document.addEventListener('DOMContentLoaded', function() {\n$script\n});" );
+			wp_add_inline_script(
+				'plausible-analytics',
+				"document.addEventListener('DOMContentLoaded', function() {\n$script\n});"
+			);
 		}
 
 		// This action allows you to add your own custom scripts!
@@ -111,7 +117,6 @@ class Actions {
 
 	/**
 	 * Create admin bar nodes.
-	 *
 	 * @since  1.3.0
 	 * @access public
 	 *

--- a/src/Admin/Provisioning.php
+++ b/src/Admin/Provisioning.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Plausible Analytics | Provisioning.
- *
  * @since      2.0.0
  * @package    WordPress
  * @subpackage Plausible Analytics
@@ -68,10 +67,11 @@ class Provisioning {
 		}
 
 		$this->custom_event_goals = [
-			'404'            => __( '404', 'plausible-analytics' ),
-			'outbound-links' => __( 'Outbound Link: Click', 'plausible-analytics' ),
-			'file-downloads' => __( 'File Download', 'plausible-analytics' ),
-			'search'         => __( 'WP Search Queries', 'plausible-analytics' ),
+			'404'              => __( '404', 'plausible-analytics' ),
+			'outbound-links'   => __( 'Outbound Link: Click', 'plausible-analytics' ),
+			'file-downloads'   => __( 'File Download', 'plausible-analytics' ),
+			'search'           => __( 'WP Search Queries', 'plausible-analytics' ),
+			'form-completions' => __( 'Form Completions', 'plausible-analytics' ),
 		];
 
 		$this->init();
@@ -79,10 +79,8 @@ class Provisioning {
 
 	/**
 	 * Action & filter hooks.
-	 *
 	 * @return void
 	 * @throws ApiException
-	 *
 	 * @codeCoverageIgnore
 	 */
 	private function init() {
@@ -210,11 +208,11 @@ class Provisioning {
 	 * @param $settings
 	 *
 	 * @return void
-	 *
 	 * @codeCoverageIgnore Because we don't want to test the API.
 	 */
 	public function maybe_create_woocommerce_funnel( $old_settings, $settings ) {
-		if ( ! Helpers::is_enhanced_measurement_enabled( 'revenue', $settings[ 'enhanced_measurements' ] ) || ! Integrations::is_wc_active() ) {
+		if ( ! Helpers::is_enhanced_measurement_enabled( 'revenue', $settings[ 'enhanced_measurements' ] ) ||
+			! Integrations::is_wc_active() ) {
 			return; // @codeCoverageIgnore
 		}
 
@@ -254,7 +252,6 @@ class Provisioning {
 	 * @param $steps
 	 *
 	 * @return void
-	 *
 	 * @codeCoverageIgnore Because this method should be mocked in tests if needed.
 	 */
 	private function create_funnel( $name, $steps ) {
@@ -325,14 +322,13 @@ class Provisioning {
 	}
 
 	/**
-	 * Delete all custom WooCommerce event goals if Revenue setting is disabled. The funnel is deleted when the minimum required no. of goals is no
-	 * longer met.
+	 * Delete all custom WooCommerce event goals if Revenue setting is disabled. The funnel is deleted when the minimum
+	 * required no. of goals is no longer met.
 	 *
 	 * @param $old_settings
 	 * @param $settings
 	 *
 	 * @return void
-	 *
 	 * @codeCoverageIgnore Because we don't want to test if the API is working.
 	 */
 	public function maybe_delete_woocommerce_goals( $old_settings, $settings ) {
@@ -361,14 +357,13 @@ class Provisioning {
 	}
 
 	/**
-	 * Searches an array for the presence of $string within each element's value. Strips currencies using a regex, e.g. (USD), because these are
-	 * added to revenue goals by Plausible.
+	 * Searches an array for the presence of $string within each element's value. Strips currencies using a regex, e.g.
+	 * (USD), because these are added to revenue goals by Plausible.
 	 *
 	 * @param string $string
 	 * @param array  $haystack
 	 *
 	 * @return false|mixed
-	 *
 	 * @codeCoverageIgnore Because it can't be unit tested.
 	 */
 	private function array_search_contains( $string, $haystack ) {
@@ -390,7 +385,6 @@ class Provisioning {
 	 * @param array $settings
 	 *
 	 * @return void
-	 *
 	 * @codeCoverageIgnore Because we don't want to test if the API is working.
 	 */
 	public function maybe_create_custom_properties( $old_settings, $settings ) {
@@ -398,7 +392,8 @@ class Provisioning {
 
 		if ( ! Helpers::is_enhanced_measurement_enabled( 'pageview-props', $enhanced_measurements ) &&
 			! Helpers::is_enhanced_measurement_enabled( 'revenue', $enhanced_measurements ) &&
-			! Helpers::is_enhanced_measurement_enabled( 'search', $enhanced_measurements ) ) {
+			! Helpers::is_enhanced_measurement_enabled( 'search', $enhanced_measurements ) &&
+			! Helpers::is_enhanced_measurement_enabled( 'form-completions', $enhanced_measurements ) ) {
 			return; // @codeCoverageIgnore
 		}
 
@@ -417,7 +412,8 @@ class Provisioning {
 		/**
 		 * Create Custom Properties for WooCommerce integration.
 		 */
-		if ( Helpers::is_enhanced_measurement_enabled( 'revenue', $enhanced_measurements ) && Integrations::is_wc_active() ) {
+		if ( Helpers::is_enhanced_measurement_enabled( 'revenue', $enhanced_measurements ) &&
+			Integrations::is_wc_active() ) {
 			foreach ( WooCommerce::CUSTOM_PROPERTIES as $property ) {
 				$properties[] = new Client\Model\CustomProp( [ 'custom_prop' => [ 'key' => $property ] ] );
 			}
@@ -430,6 +426,10 @@ class Provisioning {
 			foreach ( $this->custom_search_properties as $property ) {
 				$properties[] = new Client\Model\CustomProp( [ 'custom_prop' => [ 'key' => $property ] ] );
 			}
+		}
+
+		if ( Helpers::is_enhanced_measurement_enabled( 'form-completions', $enhanced_measurements ) ) {
+			$properties[] = new Client\Model\CustomProp( [ 'custom_prop' => [ 'key' => 'form' ] ] );
 		}
 
 		if ( empty( $properties ) ) {

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -191,7 +191,7 @@ class Page extends API {
 						],
 						'form-completions' => [
 							'label' => esc_html__( 'Form completions', 'plausible-analytics' ),
-							'docs'  => '',
+							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-form-completions',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'form-completions',

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -2,7 +2,6 @@
 
 /**
  * Plausible Analytics | Settings API.
- *
  * @since      1.3.0
  * @package    WordPress
  * @subpackage Plausible Analytics
@@ -72,7 +71,6 @@ class Page extends API {
 
 	/**
 	 * Constructor.
-	 *
 	 * @since  1.3.0
 	 * @access public
 	 * @return void
@@ -120,7 +118,8 @@ class Page extends API {
 						],
 						[
 							'label'    => empty( $settings[ 'domain_name' ] ) || empty( $settings[ 'api_token' ] ) ?
-								esc_html__( 'Connect', 'plausible-analytics' ) : esc_html__( 'Connected', 'plausible-analytics' ),
+								esc_html__( 'Connect', 'plausible-analytics' ) :
+								esc_html__( 'Connected', 'plausible-analytics' ),
 							'slug'     => 'connect_plausible_analytics',
 							'type'     => 'button',
 							'disabled' => empty( $settings[ 'domain_name' ] ) ||
@@ -190,6 +189,13 @@ class Page extends API {
 							'type'  => 'checkbox',
 							'value' => 'pageview-props',
 						],
+						'form-submit'    => [
+							'label' => esc_html__( 'Form submissions', 'plausible-analytics' ),
+							'docs'  => '',
+							'slug'  => 'enhanced_measurements',
+							'type'  => 'checkbox',
+							'value' => 'form-submit',
+						],
 						'hash'           => [
 							'label' => esc_html__( 'Hash-based routing', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-enable-hash-based-url-tracking',
@@ -221,7 +227,8 @@ class Page extends API {
 						get_site_url( null, rest_get_url_prefix() ),
 						empty(
 						Helpers::get_settings()[ 'proxy_enabled' ]
-						) ? 'a random directory/file for storing the JS file' : 'a JS file, called <code>' . str_replace(
+						) ? 'a random directory/file for storing the JS file' :
+							'a JS file, called <code>' . str_replace(
 								ABSPATH,
 								'',
 								Helpers::get_proxy_resource( 'cache_dir' ) . Helpers::get_proxy_resource(
@@ -256,7 +263,8 @@ class Page extends API {
 							'slug'     => 'enable_analytics_dashboard',
 							'type'     => 'checkbox',
 							'value'    => 'on',
-							'disabled' => empty( Helpers::get_settings()[ 'api_token' ] ) && empty( Helpers::get_settings()[ 'self_hosted_domain' ] ),
+							'disabled' => empty( Helpers::get_settings()[ 'api_token' ] ) &&
+								empty( Helpers::get_settings()[ 'self_hosted_domain' ] ),
 						],
 					],
 				],
@@ -377,15 +385,13 @@ class Page extends API {
 					'slug'   => 'self_hosted_shared_link',
 					'type'   => 'group',
 					'desc'   => sprintf(
-						'<ol><li>' .
-						__(
+						'<ol><li>' . __(
 							'<a href="%s" target="_blank">Create a secure and private shared link</a> in your Plausible account.',
 							'plausible-analytics'
-						) .
-						'<li>' .
-						__( 'Paste the shared link in the text box to view your stats in your WordPress dashboard.', 'plausible-analytics' ) .
-						'</li>' .
-						'</li></ol>',
+						) . '<li>' . __(
+							'Paste the shared link in the text box to view your stats in your WordPress dashboard.',
+							'plausible-analytics'
+						) . '</li>' . '</li></ol>',
 						esc_url( 'https://plausible.io/docs/embed-dashboard' )
 					),
 					'fields' => [
@@ -425,7 +431,6 @@ class Page extends API {
 
 		/**
 		 * If proxy is enabled, or self-hosted domain has a value, display warning box.
-		 *
 		 * @see self::proxy_warning()
 		 */
 		if ( Helpers::proxy_enabled() || ! empty( $settings[ 'self_hosted_domain' ] ) ) {
@@ -458,7 +463,6 @@ class Page extends API {
 
 	/**
 	 * Init action hooks.
-	 *
 	 * @return void
 	 */
 	private function init() {
@@ -509,7 +513,6 @@ class Page extends API {
 
 	/**
 	 * Register Menu.
-	 *
 	 * @since  1.0.0
 	 * @access public
 	 * @return void
@@ -579,7 +582,6 @@ class Page extends API {
 
 	/**
 	 * A little hack to add some classes to the core #wpcontent div.
-	 *
 	 * @return void
 	 */
 	public function add_background_color() {
@@ -590,7 +592,6 @@ class Page extends API {
 
 	/**
 	 * Statistics Page via Embed feature.
-	 *
 	 * @since  1.2.0
 	 * @access public
 	 * @return void
@@ -643,7 +644,6 @@ class Page extends API {
 		 * When this option was saved to the database, underlying code would fail, throwing a CORS related error in browsers.
 		 * Now, we explicitly check for the existence of this example "auth" key, and display a human-readable error message to
 		 * those who haven't properly set it up.
-		 *
 		 * @since v1.2.5
 		 * For self-hosters the View Stats option doesn't need to be enabled, if a Shared Link is entered, we can assume they want to View Stats.
 		 * For regular users, the shared link is provisioned by the API, so it shouldn't be empty.
@@ -707,7 +707,10 @@ class Page extends API {
 						); ?>
 					<?php else: ?>
 						<?php echo sprintf(
-							__( 'Please <a href="%s">click here</a> to enable <strong>View Stats in WordPress</strong>.', 'plausible-analytics' ),
+							__(
+								'Please <a href="%s">click here</a> to enable <strong>View Stats in WordPress</strong>.',
+								'plausible-analytics'
+							),
 							admin_url( 'options-general.php?page=plausible_analytics#is_shared_link' )
 						);
 						?>

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -139,42 +139,42 @@ class Page extends API {
 						'plausible-analytics'
 					),
 					'fields' => [
-						'404'            => [
+						'404'              => [
 							'label' => esc_html__( '404 error pages', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-404-error-pages',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => '404',
 						],
-						'outbound-links' => [
+						'outbound-links'   => [
 							'label' => esc_html__( 'Outbound links', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-external-link-clicks',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'outbound-links',
 						],
-						'file-downloads' => [
+						'file-downloads'   => [
 							'label' => esc_html__( 'File downloads', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-file-downloads',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'file-downloads',
 						],
-						'search'         => [
+						'search'           => [
 							'label' => esc_html__( 'Search queries', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-enable-site-search-tracking',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'search',
 						],
-						'tagged-events'  => [
+						'tagged-events'    => [
 							'label' => esc_html__( 'Custom events', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-setup-custom-events-to-track-goal-conversions',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'tagged-events',
 						],
-						'revenue'        => [
+						'revenue'          => [
 							'label'    => esc_html__( 'Ecommerce revenue', 'plausible-analytics' ),
 							'docs'     => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-ecommerce-revenue',
 							'slug'     => 'enhanced_measurements',
@@ -182,28 +182,28 @@ class Page extends API {
 							'value'    => 'revenue',
 							'disabled' => ! empty( $settings[ 'self_hosted_domain' ] ),
 						],
-						'pageview-props' => [
+						'pageview-props'   => [
 							'label' => esc_html__( 'Authors and categories', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-send-custom-properties',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'pageview-props',
 						],
-						'form-submit'    => [
-							'label' => esc_html__( 'Form submissions', 'plausible-analytics' ),
+						'form-completions' => [
+							'label' => esc_html__( 'Form completions', 'plausible-analytics' ),
 							'docs'  => '',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
-							'value' => 'form-submit',
+							'value' => 'form-completions',
 						],
-						'hash'           => [
+						'hash'             => [
 							'label' => esc_html__( 'Hash-based routing', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-enable-hash-based-url-tracking',
 							'slug'  => 'enhanced_measurements',
 							'type'  => 'checkbox',
 							'value' => 'hash',
 						],
-						'compat'         => [
+						'compat'           => [
 							'label' => esc_html__( 'IE compatibility', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-visitors-who-use-internet-explorer',
 							'slug'  => 'enhanced_measurements',

--- a/src/Integrations.php
+++ b/src/Integrations.php
@@ -2,7 +2,6 @@
 
 /**
  * Plausible Analytics | Integrations
- *
  * @since      2.1.0
  * @package    WordPress
  * @subpackage Plausible Analytics
@@ -25,7 +24,6 @@ class Integrations {
 
 	/**
 	 * Run available integrations.
-	 *
 	 * @return void
 	 */
 	private function init() {
@@ -38,11 +36,14 @@ class Integrations {
 		if ( self::is_edd_active() ) {
 			// new Integrations\EDD();
 		}
+
+		if ( self::is_form_submit_active() ) {
+			new Integrations\FormSubmit();
+		}
 	}
 
 	/**
 	 * Checks if WooCommerce is installed and activated.
-	 *
 	 * @return bool
 	 */
 	public static function is_wc_active() {
@@ -51,10 +52,20 @@ class Integrations {
 
 	/**
 	 * Checks if Easy Digital Downloads is installed and activated.
-	 *
 	 * @return bool
 	 */
 	public static function is_edd_active() {
 		return apply_filters( 'plausible_analytics_integrations_edd', function_exists( 'EDD' ) );
+	}
+
+	/**
+	 * Check if Form Submissions option is enabled in Enhanced Measurements.
+	 * @return mixed|null
+	 */
+	public static function is_form_submit_active() {
+		return apply_filters(
+			'plausible_analytics_integrations_form_submit',
+			Helpers::is_enhanced_measurement_enabled( 'form-submit' )
+		);
 	}
 }

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -8,6 +8,8 @@
 
 namespace Plausible\Analytics\WP\Integrations;
 
+use Plausible\Analytics\WP\Proxy;
+
 class FormSubmit {
 	/**
 	 * Build class.
@@ -25,6 +27,10 @@ class FormSubmit {
 		 * Adds required JS and classes.
 		 */
 		add_action( 'wp_enqueue_scripts', [ $this, 'add_js' ], 1 );
+		/**
+		 * Contact Form 7 doesn't respect JS checkValidity() function.
+		 */
+		add_filter( 'wpcf7_validate', [ $this, 'wpcf7_validate' ], 10, 2 );
 	}
 
 	/**
@@ -32,6 +38,10 @@ class FormSubmit {
 	 * @return void
 	 */
 	public function add_js() {
+		if ( defined( 'WPCF7_VERSION' ) ) {
+			return;
+		}
+
 		wp_register_script(
 			'plausible-form-submit-integration',
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
@@ -46,5 +56,32 @@ class FormSubmit {
 		);
 
 		wp_enqueue_script( 'plausible-form-submit-integration' );
+	}
+
+	/**
+	 * Tracks the form submission if form is valid.
+	 *
+	 * @param \WPCF7_Validation $result Form submission result object containing validation results.
+	 * @param array             $tags   Array of tags associated with the form fields.
+	 *
+	 * @return \WPCF7_Validation
+	 */
+	public function wpcf7_validate( $result, $tags ) {
+		$invalid_fields = $result->get_invalid_fields();
+
+		if ( empty( $invalid_fields ) ) {
+			$post = get_post( $_POST[ '_wpcf7_container_post' ] );
+			$uri  = '/' . $post->post_name . '/';
+
+			$proxy = new Proxy( false );
+			$proxy->do_request(
+				__( 'Form Completions', 'plausible-analytics' ),
+				null,
+				null,
+				[ 'form' => $uri ]
+			);
+		}
+
+		return $result;
 	}
 }

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plausible Analytics | Integrations | Form Submissions.
+ * @since      2.2.0
+ * @package    WordPress
+ * @subpackage Plausible Analytics
+ */
+
+namespace Plausible\Analytics\WP\Integrations;
+
+class FormSubmit {
+	/**
+	 * Build class.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Init
+	 * @return void
+	 */
+	private function init() {
+		/**
+		 * Adds required JS and classes.
+		 */
+		add_action( 'wp_enqueue_scripts', [ $this, 'add_js' ], 1 );
+	}
+
+	/**
+	 * Enqueues the required JavaScript for form submissions integration.
+	 * @return void
+	 */
+	public function add_js() {
+		wp_enqueue_script(
+			'plausible-form-submit-integration',
+			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
+			[],
+			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' )
+		);
+	}
+}

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -32,11 +32,19 @@ class FormSubmit {
 	 * @return void
 	 */
 	public function add_js() {
-		wp_enqueue_script(
+		wp_register_script(
 			'plausible-form-submit-integration',
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
-			[],
+			[ 'plausible-analytics' ],
 			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' )
 		);
+
+		wp_localize_script(
+			'plausible-form-submit-integration',
+			'plausible_analytics_i18n',
+			[ 'form_completions' => __( 'Form Completions', 'plausible-analytics' ), ]
+		);
+
+		wp_enqueue_script( 'plausible-form-submit-integration' );
 	}
 }

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -28,9 +28,9 @@ class FormSubmit {
 		 */
 		add_action( 'wp_enqueue_scripts', [ $this, 'add_js' ], 1 );
 		/**
-		 * Contact Form 7 doesn't respect JS checkValidity() function.
+		 * Contact Form 7 doesn't respect JS checkValidity() function, so this is a custom compatibility fix.
 		 */
-		add_filter( 'wpcf7_validate', [ $this, 'wpcf7_validate' ], 10, 2 );
+		add_filter( 'wpcf7_validate', [ $this, 'maybe_track_submission' ], 10, 2 );
 	}
 
 	/**
@@ -59,14 +59,14 @@ class FormSubmit {
 	}
 
 	/**
-	 * Tracks the form submission if form is valid.
+	 * Tracks the form submission if CF7 says it's valid.
 	 *
 	 * @param \WPCF7_Validation $result Form submission result object containing validation results.
 	 * @param array             $tags   Array of tags associated with the form fields.
 	 *
 	 * @return \WPCF7_Validation
 	 */
-	public function wpcf7_validate( $result, $tags ) {
+	public function maybe_track_submission( $result, $tags ) {
 		$invalid_fields = $result->get_invalid_fields();
 
 		if ( empty( $invalid_fields ) ) {

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -13,6 +13,7 @@ use Plausible\Analytics\WP\Proxy;
 class FormSubmit {
 	/**
 	 * Build class.
+	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
 		$this->init();
@@ -21,6 +22,7 @@ class FormSubmit {
 	/**
 	 * Init
 	 * @return void
+	 * @codeCoverageIgnore
 	 */
 	private function init() {
 		/**
@@ -36,6 +38,7 @@ class FormSubmit {
 	/**
 	 * Enqueues the required JavaScript for form submissions integration.
 	 * @return void
+	 * @codeCoverageIgnore because there's nothing to test here.
 	 */
 	public function add_js() {
 		if ( defined( 'WPCF7_VERSION' ) ) {
@@ -65,6 +68,7 @@ class FormSubmit {
 	 * @param array             $tags   Array of tags associated with the form fields.
 	 *
 	 * @return \WPCF7_Validation
+	 * @codeCoverageIgnore because we can't test XHR requests here.
 	 */
 	public function maybe_track_submission( $result, $tags ) {
 		$invalid_fields = $result->get_invalid_fields();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ const config = {
 	mode,
 	entry: {
 		'plausible-admin': ['./assets/src/css/admin/main.css', './assets/src/js/admin/main.js'],
-		'plausible-woocommerce-integration': ['./assets/src/js/integrations/woocommerce.js']
+		'plausible-woocommerce-integration': ['./assets/src/js/integrations/woocommerce.js'],
+		'plausible-form-submit-integration': ['./assets/src/js/integrations/form-submit.js']
 	},
 	output: {
 		path: path.join(__dirname, './assets/dist/'),


### PR DESCRIPTION
This PR adds an option, called Form completions, to the Enhanced Measurements section:

![image](https://github.com/user-attachments/assets/e18fa5e3-22c3-41d0-83c6-ea2573573aa8)

Once enabled, a Custom Event goal is created, called Form Completions, with a custom property, called `form`.

JS is enqueued in the frontend to track form submissions, which uses the `checkValidity()` function to verify the form before tracking the submission. This is tested with WP Forms, Elementor Pro Forms and Ninja Forms and should work for most forms plugins.

Contact Form 7 uses a custom validation method, so a custom compatibility fix is added for that, too.