### PR TITLE
feat: defer plausible-analytics script

### DIFF
--- a/src/Actions.php
+++ b/src/Actions.php
@@ -60,7 +60,10 @@ class Actions {
 			Helpers::get_js_url( true ),
 			'',
 			$version,
-			apply_filters( 'plausible_load_js_in_footer', false )
+			[
+				'in_footer' => apply_filters( 'plausible_load_js_in_footer', false ),
+				'strategy' => 'defer',
+			]
 		);
 
 		// Goal tracking inline script (Don't disable this as it is required by 404).


### PR DESCRIPTION
Since WordPress 6.3, we've been able to defer scripts. The plausible-analytic script is a good candidate for this.

https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/