### PR TITLE
Fix 500 errors on old ?add-to-cart= links

### DIFF
--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -204,6 +204,9 @@ class WooCommerce {
 	 * @codeCoverageIgnore Because we can't test XHR requests here.
 	 */
 	public function track_add_to_cart( $product, $add_to_cart_data ) {
+		if ( !$product ) {
+			return;
+		}
 		$product_data  = $this->clean_data( $product->get_data() );
 		$added_to_cart = $this->clean_data( $add_to_cart_data );
 		$cart          = WC()->cart;


### PR DESCRIPTION
Getting 500 errors in Google Search console from old links to `site.com/?add-to-cart=832` where that product ID isn't for sale anymore.

Error: `Call to a member function get_data() on false in /wp-content/plugins/plausible-analytics/src/Integrations/WooCommerce.php:207`

Don't track if product not available anymore.