### PR TITLE
Added: Track Query Parameters option to Enhanced Measurements

### DIFF
--- a/src/Actions.php
+++ b/src/Actions.php
@@ -130,6 +130,7 @@ class Actions {
 			);
 		}
 
+		// Track query parameters (if enabled and set)
 		if ( Helpers::is_enhanced_measurement_enabled( 'query-params' ) ) {
 			$query_params = Helpers::get_settings()['query_params'] ?? [];
 			$props        = [];
@@ -147,7 +148,7 @@ class Actions {
 					]
 				);
 
-				$script = "plausible('Query Parameters', $data );";
+				$script = "plausible('WP Query Parameters', $data );";
 
 				wp_add_inline_script(
 					'plausible-analytics',

--- a/src/Actions.php
+++ b/src/Actions.php
@@ -130,6 +130,32 @@ class Actions {
 			);
 		}
 
+		if ( Helpers::is_enhanced_measurement_enabled( 'query-params' ) ) {
+			$query_params = Helpers::get_settings()['query_params'] ?? [];
+			$props        = [];
+
+			foreach ( $query_params as $query_param ) {
+				if ( isset( $_REQUEST[ $query_param ] ) ) {
+					$props[ $query_param ] = $_REQUEST[ $query_param ];
+				}
+			}
+
+			if ( ! empty( $props ) ) {
+				$data = wp_json_encode(
+					[
+						'props' => $props,
+					]
+				);
+
+				$script = "plausible('Query Parameters', $data );";
+
+				wp_add_inline_script(
+					'plausible-analytics',
+					"document.addEventListener('DOMContentLoaded', function() {\n$script\n});"
+				);
+			}
+		}
+
 		// Track search results. Tracks a search event with the search term and the number of results, and a pageview with the site's search URL.
 		if ( Helpers::is_enhanced_measurement_enabled( 'search' ) && is_search() ) {
 			global $wp_query;
@@ -138,7 +164,7 @@ class Actions {
 			$data          = wp_json_encode(
 				[
 					'props' => [
-						// convert queries to lowercase and remove trailing whitespace to ensure same terms are grouped together
+						// convert queries to lowercase and remove trailing whitespace to ensure the same terms are grouped together
 						'search_query'  => strtolower( trim( get_search_query() ) ),
 						'result_count'  => $wp_query->found_posts,
 						'search_source' => $search_source,

--- a/src/Actions.php
+++ b/src/Actions.php
@@ -152,7 +152,7 @@ class Actions {
 
 				wp_add_inline_script(
 					'plausible-analytics',
-					"document.addEventListener('DOMContentLoaded', function() {\n$script\n});"
+					"document.addEventListener('DOMContentLoaded', function () {\n$script\n});"
 				);
 			}
 		}
@@ -176,7 +176,7 @@ class Actions {
 
 			wp_add_inline_script(
 				'plausible-analytics',
-				"document.addEventListener('DOMContentLoaded', function() {\n$script\n});"
+				"document.addEventListener('DOMContentLoaded', function () {\n$script\n});"
 			);
 		}
 

--- a/src/Admin/Provisioning.php
+++ b/src/Admin/Provisioning.php
@@ -91,7 +91,7 @@ class Provisioning {
 			'file-downloads'   => __( 'File Download', 'plausible-analytics' ),
 			'form-completions' => __( 'WP Form Completions', 'plausible-analytics' ),
 			'outbound-links'   => __( 'Outbound Link: Click', 'plausible-analytics' ),
-			'query-params' => __( 'Query Parameters', 'plausible-analytics' ),
+			'query-params'     => __( 'WP Query Parameters', 'plausible-analytics' ),
 			'search'           => __( 'WP Search Queries', 'plausible-analytics' ),
 		];
 

--- a/src/Admin/Provisioning.php
+++ b/src/Admin/Provisioning.php
@@ -91,6 +91,7 @@ class Provisioning {
 			'file-downloads'   => __( 'File Download', 'plausible-analytics' ),
 			'form-completions' => __( 'WP Form Completions', 'plausible-analytics' ),
 			'outbound-links'   => __( 'Outbound Link: Click', 'plausible-analytics' ),
+			'query-params' => __( 'Query Parameters', 'plausible-analytics' ),
 			'search'           => __( 'WP Search Queries', 'plausible-analytics' ),
 		];
 
@@ -334,7 +335,8 @@ class Provisioning {
 
 		if ( ! Helpers::is_enhanced_measurement_enabled( 'pageview-props', $enhanced_measurements ) &&
 			! Helpers::is_enhanced_measurement_enabled( 'revenue', $enhanced_measurements ) &&
-			! Helpers::is_enhanced_measurement_enabled( 'search', $enhanced_measurements ) ) {
+			! Helpers::is_enhanced_measurement_enabled( 'search', $enhanced_measurements ) &&
+			! Helpers::is_enhanced_measurement_enabled( 'query-params', $enhanced_measurements ) ) {
 			return; // @codeCoverageIgnore
 		}
 
@@ -356,6 +358,15 @@ class Provisioning {
 		if ( Helpers::is_enhanced_measurement_enabled( 'revenue', $enhanced_measurements ) && ( Integrations::is_wc_active() || Integrations::is_edd_active() ) ) {
 			foreach ( self::CUSTOM_PROPERTIES as $property ) {
 				$properties[] = new Client\Model\CustomProp( [ 'custom_prop' => [ 'key' => $property ] ] );
+			}
+		}
+
+		/**
+		 * Create Custom Properties for Query Parameters option.
+		 */
+		if ( Helpers::is_enhanced_measurement_enabled( 'query-params', $enhanced_measurements ) ) {
+			foreach ( Helpers::get_settings()['query_params'] ?? [] as $query_param ) {
+				$properties[] = new Client\Model\CustomProp( [ 'custom_prop' => [ 'key' => $query_param ] ] );
 			}
 		}
 

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -221,6 +221,28 @@ class Page extends API {
 							'value' => 'user-logged-in',
 							'caps'  => [ self::CAP_PROPS ],
 						],
+						'query-params'          => [
+							'label'      => esc_html__( 'Query parameters', 'plausible-analytics' ),
+							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-query-parameters',
+							'slug'       => 'enhanced_measurements',
+							'type'       => 'checkbox',
+							'value'      => 'query-params',
+							'addtl_opts' => true,
+							'caps'       => [ self::CAP_PROPS ],
+						],
+						'query-params-patterns' => [
+							'slug'        => 'query_params',
+							'description' => sprintf(
+								__(
+									'Enter the query parameters you\'d like to track. E.g. enter <strong>lang</strong> if you want to track <code>%s</code>.',
+									'plausible-analytics'
+								),
+								get_home_url() . '?lang=en'
+							),
+							'type'        => 'clonable_text',
+							'value'       => Helpers::get_settings()['query-params'] ?? [],
+							'hidden'      => ! Helpers::is_enhanced_measurement_enabled( 'query-params' ),
+						],
 						'search'                   => [
 							'label' => esc_html__( 'Search queries', 'plausible-analytics' ),
 							'docs'  => 'https://plausible.io/wordpress-analytics-plugin#how-to-enable-site-search-tracking',

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -223,7 +223,7 @@ class Page extends API {
 						],
 						'query-params'          => [
 							'label'      => esc_html__( 'Query parameters', 'plausible-analytics' ),
-							'docs'       => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-query-parameters',
+							'docs' => 'https://plausible.io/wordpress-analytics-plugin#how-to-track-custom-query-parameters',
 							'slug'       => 'enhanced_measurements',
 							'type'       => 'checkbox',
 							'value'      => 'query-params',

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -240,7 +240,7 @@ class Page extends API {
 								get_home_url() . '?lang=en'
 							),
 							'type'        => 'clonable_text',
-							'value'       => Helpers::get_settings()['query-params'] ?? [],
+							'value' => Helpers::get_settings()['query_params'] ?? [],
 							'hidden'      => ! Helpers::is_enhanced_measurement_enabled( 'query-params' ),
 						],
 						'search'                   => [


### PR DESCRIPTION
This PR addresses https://github.com/plausible/wordpress/issues/160 and adds a Query Parameters option to Enhanced Measurements, which allows users to define which query parameters (e.g. ?lang=en) they'd like to track. Enabling the option displays a form in which the field is clonable, to allow for entering multiple values.

<img width="1002" height="233" alt="afbeelding" src="https://github.com/user-attachments/assets/3c0cf574-3c71-453f-b1ae-4ea0aea67337" />

Provisioning automatically creates the goal *WP Query Parameters* upon enabling the option. A custom property is created for each entered query parameter when hitting _Save_.

The tracking code is only rendered when the query parameters are present in the URL.