### PR TITLE
Fixed: CE users (that weren't using the Plugins API) would get a critical error after updating to v2.5.1

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -48,7 +48,11 @@ class Helpers {
 	public static function get_filename() {
 		$client = static::get_client();
 
-		return $client->get_tracker_id();
+		if ( ! $client instanceof Client ) {
+			return $client->get_tracker_id();
+		}
+
+		return '';
 	}
 
 	/**

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -48,7 +48,7 @@ class Helpers {
 	public static function get_filename() {
 		$client = static::get_client();
 
-		if ( ! $client instanceof Client ) {
+		if ( $client instanceof Client ) {
 			return $client->get_tracker_id();
 		}
 


### PR DESCRIPTION
I still have to fix the automated tests, but this change is save to be released.