### PR TITLE
Fixed: only load author/category pageview props on posts.

### DIFF
--- a/src/InitOptions.php
+++ b/src/InitOptions.php
@@ -16,9 +16,9 @@ class InitOptions {
 	/**
 	 * Constructor.
 	 *
-	 * @return void
 	 * @since  1.0.0
 	 * @access public
+	 * @return void
 	 */
 	public function __construct() {
 		add_filter( 'plausible_analytics_init_options', [ $this, 'maybe_add_pageview_props' ] );
@@ -43,7 +43,7 @@ class InitOptions {
 
 		global $post;
 
-		if ( ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof WP_Post || ! is_single() ) {
 			return $options; // @codeCoverageIgnore
 		}
 
@@ -164,11 +164,11 @@ class InitOptions {
 	/**
 	 * Adds a custom parameter User Logged In if Custom Properties is enabled.
 	 *
+	 * @since v2.4.0
+	 *
 	 * @param $options
 	 *
 	 * @return array
-	 * @since v2.4.0
-	 *
 	 */
 	public function maybe_track_logged_in_users( $options = [] ) {
 		$settings = Helpers::get_settings();

--- a/tests/integration/InitOptionsTest.php
+++ b/tests/integration/InitOptionsTest.php
@@ -16,6 +16,8 @@ class InitOptionsTest extends TestCase {
 	public function testAddPageviewProps() {
 		try {
 			global $post, $wp_query;
+			$old_post  = $post;
+			$old_query = $wp_query;
 
 			$post_id             = wp_insert_post(
 				[
@@ -42,8 +44,8 @@ class InitOptionsTest extends TestCase {
 			$this->assertArrayHasKey( 'category', $options['customProperties'] );
 			$this->assertEquals( 'Uncategorized', $options['customProperties']['category'] );
 		} finally {
-			$post     = null;
-			$wp_query = null;
+			$post     = $old_post;
+			$wp_query = $old_query;
 			remove_filter( 'plausible_analytics_settings', [ $this, 'enablePageviewProps' ] );
 		}
 	}

--- a/tests/integration/InitOptionsTest.php
+++ b/tests/integration/InitOptionsTest.php
@@ -42,7 +42,8 @@ class InitOptionsTest extends TestCase {
 			$this->assertArrayHasKey( 'category', $options['customProperties'] );
 			$this->assertEquals( 'Uncategorized', $options['customProperties']['category'] );
 		} finally {
-			$post = null;
+			$post     = null;
+			$wp_query = null;
 			remove_filter( 'plausible_analytics_settings', [ $this, 'enablePageviewProps' ] );
 		}
 	}

--- a/tests/integration/InitOptionsTest.php
+++ b/tests/integration/InitOptionsTest.php
@@ -10,14 +10,14 @@ use Plausible\Analytics\WP\InitOptions;
 
 class InitOptionsTest extends TestCase {
 	/**
-	 * @return void
 	 * @see InitOptions::maybe_add_pageview_props()
+	 * @return void
 	 */
 	public function testAddPageviewProps() {
 		try {
-			global $post;
+			global $post, $wp_query;
 
-			$post_id   = wp_insert_post(
+			$post_id             = wp_insert_post(
 				[
 					'id'           => 1,
 					'post_author'  => 1,
@@ -25,8 +25,10 @@ class InitOptionsTest extends TestCase {
 					'post_content' => 'Test',
 				]
 			);
-			$test_post = get_post( $post_id );
-			$post      = $test_post;
+			$test_post           = get_post( $post_id );
+			$post                = $test_post;
+			$wp_query            = new \WP_Query();
+			$wp_query->is_single = true;
 
 			add_filter( 'plausible_analytics_settings', [ $this, 'enablePageviewProps' ] );
 
@@ -46,9 +48,9 @@ class InitOptionsTest extends TestCase {
 	}
 
 	/**
+	 * @see InitOptions::maybe_add_proxy_options()
 	 * @return void
 	 * @throws \Exception
-	 * @see InitOptions::maybe_add_proxy_options()
 	 */
 	public function testAddProxyOptions() {
 		try {
@@ -65,8 +67,8 @@ class InitOptionsTest extends TestCase {
 	}
 
 	/**
-	 * @return void
 	 * @see InitOptions::maybe_exclude_pageview()
+	 * @return void
 	 */
 	public function testExcludePageview() {
 		/**
@@ -76,7 +78,7 @@ class InitOptionsTest extends TestCase {
 			add_filter( 'plausible_analytics_settings', [ $this, 'setExcludePageview' ] );
 
 			$class = $this->getMockBuilder( InitOptions::class )->disableOriginalConstructor()->onlyMethods( [
-				'get_current_request'
+				'get_current_request',
 			] )->getMock();
 
 			$class->method( 'get_current_request' )->willReturn( 'http://example.com/category/test' );
@@ -86,7 +88,7 @@ class InitOptionsTest extends TestCase {
 			$this->assertArrayNotHasKey( 'transformRequest', $options );
 
 			$class = $this->getMockBuilder( InitOptions::class )->disableOriginalConstructor()->onlyMethods( [
-				'get_current_request'
+				'get_current_request',
 			] )->getMock();
 
 			$class->method( 'get_current_request' )->willReturn( 'http://test.example.com/test' );
@@ -105,7 +107,7 @@ class InitOptionsTest extends TestCase {
 			add_filter( 'plausible_analytics_settings', [ $this, 'setExcludePageviewEdgeCaseAsterisk' ] );
 
 			$class = $this->getMockBuilder( InitOptions::class )->disableOriginalConstructor()->onlyMethods( [
-				'get_current_request'
+				'get_current_request',
 			] )->getMock();
 
 			$class->method( 'get_current_request' )->willReturn( 'http://example.com/test' );
@@ -124,7 +126,7 @@ class InitOptionsTest extends TestCase {
 			add_filter( 'plausible_analytics_settings', [ $this, 'setExcludePageviewEdgeCaseSpace' ] );
 
 			$class = $this->getMockBuilder( InitOptions::class )->disableOriginalConstructor()->onlyMethods( [
-				'get_current_request'
+				'get_current_request',
 			] )->getMock();
 
 			$class->method( 'get_current_request' )->willReturn( 'http://example.com/test' );
@@ -138,8 +140,8 @@ class InitOptionsTest extends TestCase {
 	}
 
 	/**
-	 * @return void
 	 * @see InitOptions::maybe_track_logged_in_users()
+	 * @return void
 	 */
 	public function testTrackLoggedInUsers() {
 		try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pageview property tracking now applies exclusively to single post pages, preventing unintended tracking in other contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->