### PR TITLE
Added: suggested content for Privacy Policy

### DIFF
--- a/src/Admin/PrivacyPolicy.php
+++ b/src/Admin/PrivacyPolicy.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plausible Analytics | Admin Actions.
+ *
+ * @since      2.5.8
+ * @package    WordPress
+ * @subpackage Plausible Analytics
+ */
+
+namespace Plausible\Analytics\WP\Admin;
+
+class PrivacyPolicy {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Action & filter hooks.
+	 *
+	 * @return void
+	 */
+	private function init() {
+		add_action( 'admin_init', [ $this, 'add_content' ] );
+	}
+
+	/**
+	 * The content to add to WP's Privacy Policy page.
+	 *
+	 * @return void
+	 */
+	public function add_content() {
+		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+			return;
+		}
+
+		$content = sprintf(
+			__( "We use Plausible Analytics to collect usage statistics about our website.
+
+Plausible is a privacy-focused analytics provider that does not use cookies or other persistent identifiers.
+
+The data collected includes information such as page URLs, referrer, device type, browser and country.
+
+The data is processed by Plausible Analytics on servers located in the European Union.
+
+For more details, see Plausible’s data policy: %s", 'plausible-analytics' ),
+			'https://plausible.io/data-policy'
+		);
+
+		wp_add_privacy_policy_content( 'Example Plugin', wp_kses_post( wpautop( $content, false ) ) );
+	}
+}

--- a/src/Admin/PrivacyPolicy.php
+++ b/src/Admin/PrivacyPolicy.php
@@ -39,12 +39,13 @@ class PrivacyPolicy {
 		$content = '<h2 class="wp-block-heading">' . __( 'Analytics', 'plausible-analytics' ) . '</h2>';
 		$content .= '<p>' . '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:', 'plausible-analytics' ) . '</strong></p>';
 		$content .= sprintf(
+		/* translators: %s: URL to Plausible's data policy page. */
 			__( "We use Plausible Analytics to collect usage statistics about our website. Plausible is a privacy-focused analytics provider that does not use cookies or other persistent identifiers.
 
 The data collected includes information such as page URLs, referrer, device type, browser and country. The data is processed by Plausible Analytics on servers located in the European Union.
 
-For more details, see Plausible’s data policy: %s", 'plausible-analytics' ),
-			'https://plausible.io/data-policy'
+For more details, see Plausible's data policy: %s", 'plausible-analytics' ),
+			'<a href="https://plausible.io/data-policy" target="_blank" rel="noopener noreferrer">https://plausible.io/data-policy</a>'
 		);
 
 		wp_add_privacy_policy_content( 'Plausible Analytics', wp_kses_post( wpautop( $content, false ) ) );

--- a/src/Admin/PrivacyPolicy.php
+++ b/src/Admin/PrivacyPolicy.php
@@ -30,6 +30,8 @@ class PrivacyPolicy {
 	 * The content to add to WP's Privacy Policy page.
 	 *
 	 * @return void
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function add_suggested_content() {
 		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {

--- a/src/Admin/PrivacyPolicy.php
+++ b/src/Admin/PrivacyPolicy.php
@@ -36,19 +36,17 @@ class PrivacyPolicy {
 			return;
 		}
 
-		$content = sprintf(
-			__( "We use Plausible Analytics to collect usage statistics about our website.
+		$content = '<h2 class="wp-block-heading">' . __( 'Analytics', 'plausible-analytics' ) . '</h2>';
+		$content .= '<p>' . '<strong class="privacy-policy-tutorial">' . __( 'Suggested text:', 'plausible-analytics' ) . '</strong></p>';
+		$content .= sprintf(
+			__( "We use Plausible Analytics to collect usage statistics about our website. Plausible is a privacy-focused analytics provider that does not use cookies or other persistent identifiers.
 
-Plausible is a privacy-focused analytics provider that does not use cookies or other persistent identifiers.
-
-The data collected includes information such as page URLs, referrer, device type, browser and country.
-
-The data is processed by Plausible Analytics on servers located in the European Union.
+The data collected includes information such as page URLs, referrer, device type, browser and country. The data is processed by Plausible Analytics on servers located in the European Union.
 
 For more details, see Plausible’s data policy: %s", 'plausible-analytics' ),
 			'https://plausible.io/data-policy'
 		);
 
-		wp_add_privacy_policy_content( 'Example Plugin', wp_kses_post( wpautop( $content, false ) ) );
+		wp_add_privacy_policy_content( 'Plausible Analytics', wp_kses_post( wpautop( $content, false ) ) );
 	}
 }

--- a/src/Admin/PrivacyPolicy.php
+++ b/src/Admin/PrivacyPolicy.php
@@ -23,7 +23,7 @@ class PrivacyPolicy {
 	 * @return void
 	 */
 	private function init() {
-		add_action( 'admin_init', [ $this, 'add_content' ] );
+		add_action( 'admin_init', [ $this, 'add_suggested_content' ] );
 	}
 
 	/**
@@ -31,7 +31,7 @@ class PrivacyPolicy {
 	 *
 	 * @return void
 	 */
-	public function add_content() {
+	public function add_suggested_content() {
 		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
 			return;
 		}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,57 @@ namespace Plausible\Analytics\WP;
  */
 final class Plugin {
 	/**
+	 * Load @see Integrations()
+	 *
+	 * @return void
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function load_integrations() {
+		new Integrations();
+	}
+
+	/**
+	 * Loads the plugin's translated strings.
+	 *
+	 * @since  1.0.0
+	 * @access public
+	 * @return void
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function load_plugin_textdomain() {
+		load_plugin_textdomain(
+			'plausible-analytics',
+			false,
+			dirname( plugin_basename( PLAUSIBLE_ANALYTICS_PLUGIN_FILE ) ) . '/languages/'
+		);
+	}
+
+	/**
+	 * Load @see Admin\Provisioning()
+	 *
+	 * @return void
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function load_provisioning() {
+		new Admin\Provisioning();
+		new Admin\Provisioning\Integrations();
+	}
+
+	/**
+	 * Load @see Admin\Settings\Page()
+	 *
+	 * @return void
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function load_settings() {
+		new Admin\Settings\Page();
+	}
+
+	/**
 	 * Registers functionality with WordPress hooks.
 	 *
 	 * @since  1.0.0
@@ -51,6 +102,7 @@ final class Plugin {
 			new Admin\Filters();
 			new Admin\Actions();
 			new Admin\Module();
+			new Admin\PrivacyPolicy();
 		}
 
 		add_action( 'init', [ $this, 'load_integrations' ] );
@@ -62,56 +114,5 @@ final class Plugin {
 		new InitOptions();
 		new Proxy();
 		new Verification();
-	}
-
-	/**
-	 * Load @see Admin\Settings\Page()
-	 *
-	 * @return void
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function load_settings() {
-		new Admin\Settings\Page();
-	}
-
-	/**
-	 * Load @see Admin\Provisioning()
-	 *
-	 * @return void
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function load_provisioning() {
-		new Admin\Provisioning();
-		new Admin\Provisioning\Integrations();
-	}
-
-	/**
-	 * Load @see Integrations()
-	 *
-	 * @return void
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function load_integrations() {
-		new Integrations();
-	}
-
-	/**
-	 * Loads the plugin's translated strings.
-	 *
-	 * @since  1.0.0
-	 * @access public
-	 * @return void
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public function load_plugin_textdomain() {
-		load_plugin_textdomain(
-			'plausible-analytics',
-			false,
-			dirname( plugin_basename( PLAUSIBLE_ANALYTICS_PLUGIN_FILE ) ) . '/languages/'
-		);
 	}
 }


### PR DESCRIPTION
Addresses #164 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WordPress Privacy Policy Integration: Adds an admin-facing suggestion that can be inserted into your site's privacy policy. The suggested, localized text explains Plausible Analytics data collection (pages, referrers, device/browser, location), notes processing in the EU, and includes a link to Plausible’s data policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->