### PR TITLE
Add translators comments and number sprintf placeholders

### DIFF
--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -97,6 +97,7 @@ class Module {
 	private function show_module_not_installed_error() {
 		$message = sprintf(
 			wp_kses(
+				// translators: %s: URL to manual proxy speed module installation instructions.
 				__(
 					'The proxy is enabled, but the proxy\'s speed module failed to install. Try <a href="%s" target="_blank">installing it manually</a>.',
 					'plausible-analytics'
@@ -211,6 +212,7 @@ class Module {
 		if ( ! $is_ssl ) {
 			Messages::set_notice(
 				sprintf(
+					// translators: %s: URL to list of potential proxy solutions.
 					__(
 						'Please check that your proxy is functioning correctly. If you encounter any issues with tracking, <a href="%s" target="_blank">click here</a> for a list of potential solutions',
 						'plausible-analytics'
@@ -227,6 +229,7 @@ class Module {
 			Messages::set_error(
 				sprintf(
 					wp_kses(
+						// translators: 1: Proxy endpoint URL, 2: URL to Plausible support.
 						__(
 							'Plausible\'s proxy couldn\'t be enabled, because the WordPress API is inaccessible. This might be due to a conflicting setting in a (security) plugin or server firewall. Make sure you whitelist requests to the Proxy\'s endpoint: <code>%1$s</code>. <a href="%2$s" target="_blank">Contact support</a> if you need help locating the issue.',
 							'plausible-analytics'

--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -70,8 +70,9 @@ class API {
 			];
 			$this->slides_description = [
 				'welcome'                    => sprintf(
+					// translators: 1: URL to Plausible website, 2: URL to Plausible registration page.
 					__(
-						'<p><a href="%s" target="_blank">Plausible Analytics</a> is an easy to use, open source, lightweight and privacy-friendly alternative to Google Analytics. We\'re super excited to have you on board!</p><p>To use our plugin, you need to <a href="%s" target="_blank">register an account</a>. To explore the product, we offer you a free 30-day trial. No credit card is required to sign up for the trial.</p><p>Already have an account? Please do follow the following steps to get the most out of your Plausible experience.</p>',
+						'<p><a href="%1$s" target="_blank">Plausible Analytics</a> is an easy to use, open source, lightweight and privacy-friendly alternative to Google Analytics. We\'re super excited to have you on board!</p><p>To use our plugin, you need to <a href="%2$s" target="_blank">register an account</a>. To explore the product, we offer you a free 30-day trial. No credit card is required to sign up for the trial.</p><p>Already have an account? Please do follow the following steps to get the most out of your Plausible experience.</p>',
 						'plausible-analytics'
 					),
 					'https://plausible.io/?utm_source=WordPress&utm_medium=Referral&utm_campaign=WordPress+plugin',
@@ -95,8 +96,9 @@ class API {
 					'plausible-analytics'
 				),
 				'success'                    => sprintf(
+					// translators: 1: URL to Plausible statistics dashboard, 2: URL to plugin settings, 3: URL to Plausible documentation, 4: URL to Plausible contact.
 					__(
-						'<p>Congrats! Your traffic is now being counted without compromising the user experience and privacy of your visitors. You can now check out <a href="%s" target="_blank">your intuitive, fast-loading and privacy-friendly dashboard</a>.</p><p>Note that visits from logged in users aren\'t tracked. If you want to track visits for certain user roles, then please specify them in the <a href="%s">plugin\'s settings</a>.</p><p>Need help? <a href="%s" target="_blank">Our documentation</a> is the best place to find most answers right away.</p><p>Still haven\'t found the answer you\'re looking for? We\'re here to help. Please <a href="%s" target="_blank">contact our support</a>.</p>',
+						'<p>Congrats! Your traffic is now being counted without compromising the user experience and privacy of your visitors. You can now check out <a href="%1$s" target="_blank">your intuitive, fast-loading and privacy-friendly dashboard</a>.</p><p>Note that visits from logged in users aren\'t tracked. If you want to track visits for certain user roles, then please specify them in the <a href="%2$s">plugin\'s settings</a>.</p><p>Need help? <a href="%3$s" target="_blank">Our documentation</a> is the best place to find most answers right away.</p><p>Still haven\'t found the answer you\'re looking for? We\'re here to help. Please <a href="%4$s" target="_blank">contact our support</a>.</p>',
 						'plausible-analytics'
 					),
 					admin_url( 'index.php?page=plausible_analytics_statistics' ),
@@ -108,8 +110,9 @@ class API {
 
 			if ( empty( $settings['enable_analytics_dashboard'] ) ) {
 				$this->slides_description['success'] = sprintf(
+					// translators: 1: URL to plugin settings, 2: URL to Plausible documentation, 3: URL to Plausible contact.
 					__(
-						'<p>Congrats! Your traffic is now being counted without compromising the user experience and privacy of your visitors.</p><p>Note that visits from logged in users aren\'t tracked. If you want to track visits for certain user roles, then please specify them in the <a href="%s">plugin\'s settings</a>.</p><p>Need help? <a href="%s" target="_blank">Our documentation</a> is the best place to find most answers right away.</p><p>Still haven\'t found the answer you\'re looking for? We\'re here to help. Please <a href="%s" target="_blank">contact our support</a>.</p>',
+						'<p>Congrats! Your traffic is now being counted without compromising the user experience and privacy of your visitors.</p><p>Note that visits from logged in users aren\'t tracked. If you want to track visits for certain user roles, then please specify them in the <a href="%1$s">plugin\'s settings</a>.</p><p>Need help? <a href="%2$s" target="_blank">Our documentation</a> is the best place to find most answers right away.</p><p>Still haven\'t found the answer you\'re looking for? We\'re here to help. Please <a href="%3$s" target="_blank">contact our support</a>.</p>',
 						'plausible-analytics'
 					),
 					admin_url( 'admin-ajax.php?action=plausible_analytics_quit_wizard&_nonce=' ) . wp_create_nonce( 'plausible_analytics_quit_wizard' ) . '&redirect=tracked_user_roles',

--- a/src/Admin/Settings/Hooks.php
+++ b/src/Admin/Settings/Hooks.php
@@ -74,6 +74,7 @@ class Hooks extends API {
 		} else {
 			echo sprintf(
 				wp_kses(
+					// translators: %s: URL to Plausible contact page.
 					__(
 						'After enabling this option, please check your Plausible dashboard to make sure stats are being recorded. Are stats not being recorded? Do <a href="%s" target="_blank">reach out to us</a>. We\'re here to help!',
 						'plausible-analytics'
@@ -110,6 +111,7 @@ class Hooks extends API {
 		if ( ! empty( Helpers::get_settings()[ 'enable_analytics_dashboard' ] ) ) {
 			echo sprintf(
 				wp_kses(
+					// translators: %s: URL to the analytics dashboard.
 					__(
 						'Your analytics dashboard is available <a href="%s">here</a>.',
 						'plausible-analytics'

--- a/src/Admin/Settings/Page.php
+++ b/src/Admin/Settings/Page.php
@@ -93,6 +93,7 @@ class Page extends API {
 					'type'   => 'group',
 					'desc'   => sprintf(
 						wp_kses(
+							// translators: %s: URL to Plausible account settings.
 							__(
 								'Ensure your domain name matches the one in <a href="%s" target="_blank">your Plausible account</a>, then <a class="hover:cursor-pointer underline plausible-create-api-token">create a Plugin Token</a> (link opens in a new window) and paste it into the \'Plugin Token\' field.',
 								'plausible-analytics'
@@ -181,6 +182,7 @@ class Page extends API {
 						'affiliate-links-patterns'                    => [
 							'slug'        => 'affiliate_links',
 							'description' => sprintf(
+								// translators: %s: Example URL to affiliate product.
 								__(
 									'Enter the (partial) URLs you\'d like to track. E.g. enter <strong>/recommends/</strong> if you want to track <code>%s</code>.',
 									'plausible-analytics'
@@ -232,6 +234,7 @@ class Page extends API {
 						'query-params-patterns'                       => [
 							'slug'        => 'query_params',
 							'description' => sprintf(
+								// translators: %s: Example URL with query parameter.
 								__(
 									'Enter the query parameters you\'d like to track. E.g. enter <strong>lang</strong> if you want to track <code>%s</code>.',
 									'plausible-analytics'
@@ -266,6 +269,7 @@ class Page extends API {
 					'type'   => 'group',
 					'desc'   => sprintf(
 						wp_kses(
+							// translators: 1: Proxy endpoint prefix, 2: Proxy endpoint details, 3: URL to learn more about proxy.
 							__(
 								'Concerned about ad blockers? You can run the Plausible script as a first-party connection from your domain name to count visitors who use ad blockers. The proxy uses WordPress\' API with a randomly generated endpoint, starting with <code>%1$s</code> and %2$s. <a href="%3$s" target="_blank">Learn more &raquo;</a>',
 								'plausible-analytics'
@@ -423,6 +427,7 @@ class Page extends API {
 					'slug'   => 'self_hosted_shared_link',
 					'type'   => 'group',
 					'desc'   => sprintf(
+						// translators: %s: URL to Plausible shared link documentation.
 						'<ol><li>' . __(
 							'<a href="%s" target="_blank">Create a secure and private shared link</a> in your Plausible account.',
 							'plausible-analytics'
@@ -439,7 +444,8 @@ class Page extends API {
 							'type'        => 'text',
 							'value'       => $settings['self_hosted_shared_link'],
 							'placeholder' => sprintf(
-								wp_kses( __( 'E.g. %s/share/%s?auth=XXXXXXXXXXXX', 'plausible-analytics' ), 'post' ),
+								// translators: 1: Plausible hosted domain URL, 2: Site domain name.
+								wp_kses( __( 'E.g. %1$s/share/%2$s?auth=XXXXXXXXXXXX', 'plausible-analytics' ), 'post' ),
 								Helpers::get_hosted_domain_url(),
 								Helpers::get_domain()
 							),
@@ -734,6 +740,7 @@ class Page extends API {
 				<p>
 					<?php if ( $settings['self_hosted_domain'] ) : ?>
 						<?php echo sprintf(
+							// translators: %s: URL to self-hosted settings page.
 							__(
 								'Please enter your <em>Shared Link</em> under <a href="%s">Self-Hosted Settings</a>.',
 								'plausible-analytics'
@@ -742,6 +749,7 @@ class Page extends API {
 						); ?>
 					<?php else: ?>
 						<?php echo sprintf(
+							// translators: %s: URL to plugin settings page.
 							__(
 								'Please <a href="%s">click here</a> to enable <strong>View Stats in WordPress</strong>.',
 								'plausible-analytics'

--- a/src/Admin/Upgrades.php
+++ b/src/Admin/Upgrades.php
@@ -409,7 +409,8 @@ class Upgrades {
 
 		?>
 		<div class="notice notice-warning">
-			<p><?php echo sprintf( __( 'A plugin token for Plausible is required. Please create one from the <a href="%s">Settings screen</a> and upgrade Plausible CE if necessary.', 'plausible-analytics' ), $url ); ?></p>
+			<p><?php // translators: %s: URL to Plausible Analytics settings page.
+			echo sprintf( __( 'A plugin token for Plausible is required. Please create one from the <a href="%s">Settings screen</a> and upgrade Plausible CE if necessary.', 'plausible-analytics' ), $url ); ?></p>
 		</div>
 		<?php
 	}
@@ -424,7 +425,8 @@ class Upgrades {
 
 		?>
 		<div class="notice notice-warning">
-			<p><?php echo sprintf( __( 'Almost there! Stats tracking requires a Plausible plugin token. Create one on the <a href="%s">Settings screen</a>, and press Connect to complete setup.', 'plausible-analytics' ), $url ); ?></p>
+			<p><?php // translators: %s: URL to Plausible Analytics settings page.
+			echo sprintf( __( 'Almost there! Stats tracking requires a Plausible plugin token. Create one on the <a href="%s">Settings screen</a>, and press Connect to complete setup.', 'plausible-analytics' ), $url ); ?></p>
 		</div>
 		<?php
 	}

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -425,8 +425,9 @@ class Ajax {
 
 			Messages::set_error(
 				sprintf(
+					// translators: 1: URL to create a new plugin token, 2: URL to read more.
 					__(
-						'Oops! The Plugin Token you used is invalid. Please <a href="%s" target="_blank">create a new token</a>. <a target="_blank" href="%s">Read more</a>',
+						'Oops! The Plugin Token you used is invalid. Please <a href="%1$s" target="_blank">create a new token</a>. <a target="_blank" href="%2$s">Read more</a>',
 						'plausible-analytics'
 					),
 					"$hosted_domain/$domain/settings/integrations?new_token=WordPress",

--- a/src/Client.php
+++ b/src/Client.php
@@ -232,6 +232,7 @@ class Client {
 		} catch ( Exception $e ) {
 			$this->send_json_error(
 				$e,
+				// translators: %s: Error message.
 				__(
 					'Something went wrong while updating tracker script configuration: %s',
 					'plausible-analytics'
@@ -303,6 +304,7 @@ class Client {
 			$result = $this->bulk_create_shared_links();
 			// @codeCoverageIgnoreStart
 		} catch ( Exception $e ) {
+			// translators: %s: Error message.
 			$this->send_json_error( $e, __( 'Something went wrong while creating Shared Link: %s', 'plausible-analytics' ) );
 			// @codeCoverageIgnoreEnd
 		}
@@ -341,6 +343,7 @@ class Client {
 		try {
 			return $this->api_instance->goalGetOrCreate( $goals );
 		} catch ( Exception $e ) {
+			// translators: %s: Error message.
 			$this->send_json_error( $e, __( 'Something went wrong while creating Custom Event Goal: %s', 'plausible-analytics' ) );
 		}
 	}
@@ -358,6 +361,7 @@ class Client {
 		try {
 			return $this->api_instance->funnelGetOrCreate( $funnel );
 		} catch ( Exception $e ) {
+			// translators: %s: Error message.
 			$this->send_json_error( $e, __( 'Something went wrong while creating Funnel: %s', 'plausible-analytics' ) );
 		}
 	}
@@ -375,6 +379,7 @@ class Client {
 		} catch ( Exception $e ) {
 			$this->send_json_error(
 				$e,
+				// translators: %s: Error message.
 				__(
 					'Something went wrong while deleting a Custom Event Goal: %s',
 					'plausible-analytics'
@@ -398,6 +403,7 @@ class Client {
 		} catch ( Exception $e ) {
 			$this->send_json_error(
 				$e,
+				// translators: %s: Error message.
 				__(
 					'Something went wrong while enabling Pageview Properties: %s',
 					'plausible-analytics'

--- a/src/Integrations/EDD.php
+++ b/src/Integrations/EDD.php
@@ -34,6 +34,7 @@ class EDD {
 		}
 
 		$this->event_goals = [
+			// translators: %s: Product page URI pattern.
 			'view-product'     => sprintf( __( 'Visit %s*', 'plausible-analytics' ), $uri ),
 			'add-to-cart'      => __( 'EDD Add to Cart', 'plausible-analytics' ),
 			'remove-from-cart' => __( 'EDD Remove from Cart', 'plausible-analytics' ),

--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -37,6 +37,7 @@ class WooCommerce {
 		}
 
 		$this->event_goals = [
+			// translators: %s: Product page URI pattern.
 			'view-product'     => sprintf( __( 'Visit %s*', 'plausible-analytics' ), $uri ),
 			'add-to-cart'      => __( 'Woo Add to Cart', 'plausible-analytics' ),
 			'remove-from-cart' => __( 'Woo Remove from Cart', 'plausible-analytics' ),


### PR DESCRIPTION
Reviewed and improved some flagged `plugin-check` issues related to internationalization:

- Added `// translators:` comments above every `__()` call that contains placeholders or HTML, giving translators the context they need
- Replaced unordered `%s` placeholders with numbered equivalents (`%1$s`, `%2$s`, etc.) in strings that contain multiple substitutions, ensuring translators can reorder them for their language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced translator context annotations for user-facing messages throughout the admin and integration modules to support more accurate translations across supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plausible/wordpress/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->