### PR TITLE
fix: add missing $in_footer parameter to wp_enqueue/register_script c…

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -40,6 +40,7 @@ class Assets {
 				PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-affiliate-links.js',
 				[ 'plausible-analytics' ],
 				filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-affiliate-links.js' ),
+				true,
 			);
 
 			$affiliate_links = Helpers::get_settings()['affiliate_links'] ?? [];

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -40,7 +40,7 @@ class Assets {
 				PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-affiliate-links.js',
 				[ 'plausible-analytics' ],
 				filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-affiliate-links.js' ),
-				true,
+				[ 'in_footer' => true ],
 			);
 
 			$affiliate_links = Helpers::get_settings()['affiliate_links'] ?? [];

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -58,7 +58,8 @@ class FormSubmit {
 			'plausible-form-submit-integration',
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
 			[ 'plausible-analytics' ],
-			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' )
+			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' ),
+			true
 		);
 
 		wp_localize_script(

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -59,7 +59,7 @@ class FormSubmit {
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
 			[ 'plausible-analytics' ],
 			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' ),
-			true
+			[ 'in_footer' => true ],
 		);
 
 		wp_localize_script(

--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -118,7 +118,7 @@ class WooCommerce {
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-woocommerce-integration.js',
 			[],
 			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-woocommerce-integration.js' ),
-			true
+			[ 'in_footer' => true ],
 		);
 	}
 

--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -117,7 +117,8 @@ class WooCommerce {
 			'plausible-woocommerce-integration',
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-woocommerce-integration.js',
 			[],
-			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-woocommerce-integration.js' )
+			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-woocommerce-integration.js' ),
+			true
 		);
 	}
 


### PR DESCRIPTION
### What

Adds the missing 5th `$in_footer` argument to three `wp_enqueue_script` / `wp_register_script` calls that were triggering the `WordPress.WP.EnqueuedResourceParameters.NotInFooter` PHPCS sniff.

**Files changed:**
- Assets.php — `wp_enqueue_script( 'plausible-affiliate-links', … )` → added `true`
- FormSubmit.php — `wp_register_script( 'plausible-form-submit-integration', … )` → added `true`
- WooCommerce.php — `wp_enqueue_script( 'plausible-woocommerce-integration', … )` → added `true`

### Why `true` (footer) for integration scripts

The **main Plausible script** (`plausible-analytics`) already correctly uses `apply_filters( 'plausible_load_js_in_footer', false )`, defaulting to `false` (header). This matches [Plausible's official docs](https://plausible.io/docs/plausible-script), which recommend placing the tracking snippet inside `<head>`.

The three scripts touched here are **secondary enhancement scripts** — they handle affiliate link cloaking, form submissions, and WooCommerce tracking. They do not need to block page rendering and can safely load in the footer. WordPress correctly handles the dependency chain: if a dependent script requests footer placement and its dependency is in the header, WordPress loads them in that order without issues.

@Dan0sz in case you think we'll have to switch them let me know.