### PR TITLE
fix: reduce readme tags to comply with 5-tag limit

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plausible Analytics ===
 Contributors: plausible, DaanvandenBergh
 Donate link: https://plausible.io/
-Tags: analytics, google analytics, web analytics, stats, privacy, google analytics alternative, woocommerce analytics, website stats, analytics dashboard, simple analytics
+Tags: analytics, privacy, google analytics alternative, woocommerce analytics, stats
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.2


### PR DESCRIPTION
WordPress.org plugin checker flags more than 5 tags as a warning.

Reduced tags from 10 to 5, keeping the most relevant and distinctive ones:
- analytics (core topic)
- privacy (key differentiator)
- google analytics alternative (primary search intent)
- woocommerce analytics (specific integration)
- stats (common search term)