### PR TITLE
fix: prefix global variable $uninstaller in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,5 +12,5 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 require_once( dirname( __FILE__ ) . '/src/Uninstall.php' );
 
-$uninstaller = new \Plausible\Analytics\WP\Uninstall();
-$uninstaller->run();
+$plausible_uninstaller = new \Plausible\Analytics\WP\Uninstall();
+$plausible_uninstaller->run();


### PR DESCRIPTION
Renames the global variable `$uninstaller` to `$plausible_uninstaller` in uninstall.php to comply with the `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound` coding standard rule, which requires all global variables to carry a plugin-specific prefix.