### PR TITLE
 Fixed: add missing $in_footer parameter to wp_enqueue/register_script calls

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -91,3 +91,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: plausible/wordpress
+        continue-on-error: true

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -40,6 +40,7 @@ class Assets {
 				PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-affiliate-links.js',
 				[ 'plausible-analytics' ],
 				filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-affiliate-links.js' ),
+				true,
 			);
 
 			$affiliate_links = Helpers::get_settings()['affiliate_links'] ?? [];

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -40,7 +40,7 @@ class Assets {
 				PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-affiliate-links.js',
 				[ 'plausible-analytics' ],
 				filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-affiliate-links.js' ),
-				true,
+				[ 'in_footer' => true ],
 			);
 
 			$affiliate_links = Helpers::get_settings()['affiliate_links'] ?? [];

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -58,7 +58,8 @@ class FormSubmit {
 			'plausible-form-submit-integration',
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
 			[ 'plausible-analytics' ],
-			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' )
+			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' ),
+			true
 		);
 
 		wp_localize_script(

--- a/src/Integrations/FormSubmit.php
+++ b/src/Integrations/FormSubmit.php
@@ -59,7 +59,7 @@ class FormSubmit {
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-form-submit-integration.js',
 			[ 'plausible-analytics' ],
 			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-form-submit-integration.js' ),
-			true
+			[ 'in_footer' => true ],
 		);
 
 		wp_localize_script(

--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -118,7 +118,7 @@ class WooCommerce {
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-woocommerce-integration.js',
 			[],
 			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-woocommerce-integration.js' ),
-			true
+			[ 'in_footer' => true ],
 		);
 	}
 

--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -117,7 +117,8 @@ class WooCommerce {
 			'plausible-woocommerce-integration',
 			PLAUSIBLE_ANALYTICS_PLUGIN_URL . 'assets/dist/js/plausible-woocommerce-integration.js',
 			[],
-			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-woocommerce-integration.js' )
+			filemtime( PLAUSIBLE_ANALYTICS_PLUGIN_DIR . 'assets/dist/js/plausible-woocommerce-integration.js' ),
+			true
 		);
 	}
 

--- a/tests/integration/AssetsTest.php
+++ b/tests/integration/AssetsTest.php
@@ -10,9 +10,76 @@ use Plausible\Analytics\WP\Assets;
 
 class AssetsTest extends TestCase {
 	/**
+	 * @see Assets::maybe_enqueue_cloaked_affiliate_links_assets()
 	 * @return void
 	 * @throws \Exception
+	 */
+	public function testEnqueueCloakedAffiliateLinksScript() {
+		try {
+			add_filter( 'plausible_analytics_settings', [ $this, 'enableCloakedAffiliateLinks' ] );
+
+			$class = $this->getMockBuilder( Assets::class )
+			              ->disableOriginalConstructor()
+			              ->onlyMethods( [ 'get_js_url' ] )
+			              ->getMock();
+
+			$this->removeAction( 'wp_enqueue_scripts', 'maybe_enqueue' );
+			$this->removeAction( 'wp_enqueue_scripts', 'maybe_enqueue', 11 );
+
+			$class->method( 'get_js_url' )
+			      ->willReturn( 'https://plausible.test/js/plausible.js' );
+
+			ob_start();
+
+			$class->maybe_enqueue_main_script();
+			$class->maybe_enqueue_cloaked_affiliate_links_assets();
+
+			do_action( 'wp_footer' );
+
+			$output = ob_get_clean();
+
+			$this->assertStringContainsString( 'plausible-affiliate-links.js', $output );
+			$this->assertStringContainsString( 'const plausibleAffiliateLinks', $output );
+		} finally {
+			remove_filter( 'plausible_analytics_settings', [ $this, 'enableCloakedAffiliateLinks' ] );
+		}
+	}
+
+	/**
+	 * @see Assets::maybe_enqueue_four_o_four_script()
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function testEnqueueFourOFourScript() {
+		try {
+			add_filter( 'plausible_analytics_settings', [ $this, 'enableFourOFour' ] );
+			add_filter( 'plausible_analytics_is_404', '__return_true' );
+
+			$class = $this->getMockBuilder( Assets::class )
+			              ->disableOriginalConstructor()
+			              ->onlyMethods( [ 'get_js_url' ] )
+			              ->getMock();
+
+			$class->method( 'get_js_url' )
+			      ->willReturn( 'https://plausible.test/js/plausible.js' );
+
+			$class->maybe_enqueue_main_script();
+			$class->maybe_enqueue_four_o_four_script();
+
+			global $wp_scripts;
+
+			$this->assertArrayHasKey( 'plausible-analytics', $wp_scripts->registered );
+			$this->assertTrue( $this->arrayHasString( '404', $wp_scripts->registered['plausible-analytics']->extra['after'] ) );
+		} finally {
+			remove_filter( 'plausible_analytics_settings', [ $this, 'enableFourOFour' ] );
+			remove_filter( 'plausible_analytics_is_404', '__return_true' );
+		}
+	}
+
+	/**
 	 * @see Assets::maybe_enqueue_main_script()
+	 * @return void
+	 * @throws \Exception
 	 */
 	public function testEnqueueMainScript() {
 		try {
@@ -47,76 +114,9 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
-	 * @return void
-	 * @throws \Exception
-	 * @see Assets::maybe_enqueue_cloaked_affiliate_links_assets()
-	 */
-	public function testEnqueueCloakedAffiliateLinksScript() {
-		try {
-			add_filter( 'plausible_analytics_settings', [ $this, 'enableCloakedAffiliateLinks' ] );
-
-			$class = $this->getMockBuilder( Assets::class )
-			              ->disableOriginalConstructor()
-			              ->onlyMethods( [ 'get_js_url' ] )
-			              ->getMock();
-
-			$this->removeAction( 'wp_enqueue_scripts', 'maybe_enqueue' );
-			$this->removeAction( 'wp_enqueue_scripts', 'maybe_enqueue', 11 );
-
-			$class->method( 'get_js_url' )
-			      ->willReturn( 'https://plausible.test/js/plausible.js' );
-
-			ob_start();
-
-			$class->maybe_enqueue_main_script();
-			$class->maybe_enqueue_cloaked_affiliate_links_assets();
-
-			do_action( 'wp_head' );
-
-			$output = ob_get_clean();
-
-			$this->assertStringContainsString( 'plausible-affiliate-links.js', $output );
-			$this->assertStringContainsString( 'const plausibleAffiliateLinks', $output );
-		} finally {
-			remove_filter( 'plausible_analytics_settings', [ $this, 'enableCloakedAffiliateLinks' ] );
-		}
-	}
-
-	/**
-	 * @return void
-	 * @throws \Exception
-	 * @see Assets::maybe_enqueue_four_o_four_script()
-	 */
-	public function testEnqueueFourOFourScript() {
-		try {
-			add_filter( 'plausible_analytics_settings', [ $this, 'enableFourOFour' ] );
-			add_filter( 'plausible_analytics_is_404', '__return_true' );
-
-			$class = $this->getMockBuilder( Assets::class )
-			              ->disableOriginalConstructor()
-			              ->onlyMethods( [ 'get_js_url' ] )
-			              ->getMock();
-
-			$class->method( 'get_js_url' )
-			      ->willReturn( 'https://plausible.test/js/plausible.js' );
-
-			$class->maybe_enqueue_main_script();
-			$class->maybe_enqueue_four_o_four_script();
-
-			global $wp_scripts;
-
-			$this->assertArrayHasKey( 'plausible-analytics', $wp_scripts->registered );
-			$this->assertTrue( $this->arrayHasString( '404', $wp_scripts->registered['plausible-analytics']->extra['after'] ) );
-		} finally {
-			remove_filter( 'plausible_analytics_settings', [ $this, 'enableFourOFour' ] );
-			remove_filter( 'plausible_analytics_is_404', '__return_true' );
-		}
-	}
-
-	/**
-	 * @return void
-	 * @throws \Exception
 	 * @see Assets::maybe_enqueue_query_params_script()
+	 * @return void
+	 * @throws \Exception
 	 */
 	public function testEnqueueQueryParamsScript() {
 		try {
@@ -146,9 +146,9 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
+	 * @see Assets::maybe_enqueue_search_queries_script()
 	 * @return void
 	 * @throws \Exception
-	 * @see Assets::maybe_enqueue_search_queries_script()
 	 */
 	public function testEnqueueSearchQueriesScript() {
 		try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Scripts for affiliate links, form submissions, and WooCommerce now load later in the page, reducing render-blocking and improving page responsiveness.
* **Tests**
  * Integration tests updated and reordered to validate footer-loading behavior and ensure cleanup after assertions.
* **Chores**
  * CI adjusted so coverage upload issues no longer fail the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->