### PR TITLE
Fixed: if Permalinks > Custom Base was previously modified with WooCommerce enabled, the view-product goal would wrongfully get a 2nd leading slash.

### DIFF
--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -33,7 +33,7 @@ class WooCommerce {
 		if ( is_multisite() ) {
 			$uri = get_blog_details()->path . $uri;
 		} else {
-			$uri = '/' . $uri;
+			$uri = '/' . trim( $uri, '/' );
 		}
 
 		$this->event_goals = [
@@ -143,25 +143,6 @@ class WooCommerce {
 	}
 
 	/**
-	 * Track add to cart actions by direct link, e.g. ?product_type=download&add-to-cart=1&quantity=1
-	 *
-	 * @return void
-	 *
-	 * @codeCoverageIgnore Because we can't test XHR here.
-	 */
-	public function track_direct_add_to_cart() {
-		if ( ! isset( $_REQUEST['add-to-cart'] ) || ! is_numeric( wp_unslash( $_REQUEST['add-to-cart'] ) ) ) {
-			return;
-		}
-
-		$product_id = absint( wp_unslash( $_REQUEST['add-to-cart'] ) );
-		$product    = wc_get_product( $product_id );
-		$quantity   = isset( $_REQUEST['quantity'] ) ? absint( wp_unslash( $_REQUEST['quantity'] ) ) : 1;
-
-		$this->track_add_to_cart( $product, [ 'id' => $product_id, 'quantity' => $quantity ] );
-	}
-
-	/**
 	 * Track regular (i.e., interactivity API) add to cart events.
 	 *
 	 * @param WC_Product $product          General information about the product added to cart.
@@ -224,6 +205,25 @@ class WooCommerce {
 	 */
 	protected function get_wc_cart() {
 		return WC()->cart;
+	}
+
+	/**
+	 * Track add to cart actions by direct link, e.g. ?product_type=download&add-to-cart=1&quantity=1
+	 *
+	 * @return void
+	 *
+	 * @codeCoverageIgnore Because we can't test XHR here.
+	 */
+	public function track_direct_add_to_cart() {
+		if ( ! isset( $_REQUEST['add-to-cart'] ) || ! is_numeric( wp_unslash( $_REQUEST['add-to-cart'] ) ) ) {
+			return;
+		}
+
+		$product_id = absint( wp_unslash( $_REQUEST['add-to-cart'] ) );
+		$product    = wc_get_product( $product_id );
+		$quantity   = isset( $_REQUEST['quantity'] ) ? absint( wp_unslash( $_REQUEST['quantity'] ) ) : 1;
+
+		$this->track_add_to_cart( $product, [ 'id' => $product_id, 'quantity' => $quantity ] );
 	}
 
 	/**

--- a/src/Integrations/WooCommerce.php
+++ b/src/Integrations/WooCommerce.php
@@ -28,12 +28,12 @@ class WooCommerce {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct( $init = true ) {
-		$uri = wc_get_permalink_structure()['product_base'];
+		$uri = trim( wc_get_permalink_structure()['product_base'], '/' );
 
 		if ( is_multisite() ) {
 			$uri = get_blog_details()->path . $uri;
 		} else {
-			$uri = '/' . trim( $uri, '/' );
+			$uri = '/' . $uri;
 		}
 
 		$this->event_goals = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved permalink/path normalization for consistent product URL handling across multisite and non-multisite setups.
  * Reorganized tracking method placement while preserving the existing add-to-cart tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->