### PR TITLE
Fix: Use `wp_safe_redirect()` instead of `wp_redirect()`

### DIFF
--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -80,7 +80,7 @@ class Actions {
 		if ( ! $wizard_done ) {
 			$url = admin_url( 'options-general.php?page=plausible_analytics#welcome_slide' );
 
-			wp_redirect( $url );
+			wp_safe_redirect( $url );
 
 			exit;
 		}

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -159,7 +159,7 @@ class Ajax {
 				$url .= '#' . $direction;
 			}
 
-			wp_redirect( $url );
+			wp_safe_redirect( $url );
 
 			exit;
 		}


### PR DESCRIPTION
Resolves two `WordPress.Security.SafeRedirect.wp_redirect_wp_redirect` warnings flagged by PHPCS.

- `src/Admin/Actions.php:83` — wizard redirect now uses `wp_safe_redirect()`
- `src/Ajax.php:162` — Ajax redirect now uses `wp_safe_redirect()`

Both calls are already followed by `exit;`, so no other changes were required. No functional changes expected since both URLs resolve to local admin URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect handling to use safer redirects in wizard and AJAX flows.
  * Maintained the existing redirect behavior while reducing the chance of unsafe destination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->