### PR TITLE
Fix: Use wp_parse_url() and wp_delete_file() instead of PHP alternatives

### DIFF
--- a/mu-plugin/plausible-proxy-speed-module.php
+++ b/mu-plugin/plausible-proxy-speed-module.php
@@ -62,7 +62,7 @@ class PlausibleProxySpeed {
 			return false;
 		}
 
-		$path = parse_url( $this->request_uri, PHP_URL_PATH );
+		$path = wp_parse_url( $this->request_uri, PHP_URL_PATH );
 
 		if ( ! is_string( $path ) || $path === '' ) {
 			return false;

--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -128,7 +128,7 @@ class Module {
 		$file_path = WP_CONTENT_DIR . '/mu-plugins/plausible-proxy-speed-module.php';
 
 		if ( file_exists( $file_path ) ) {
-			unlink( $file_path );
+			wp_delete_file( $file_path );
 		}
 
 		if ( get_option( 'plausible_analytics_created_mu_plugins_dir' ) && $this->dir_is_empty( WPMU_PLUGIN_DIR ) ) {
@@ -142,7 +142,7 @@ class Module {
 		$js_file   = $this->get_filename();
 
 		if ( file_exists( $cache_dir . $js_file . '.js' ) ) {
-			unlink( $cache_dir . $js_file . '.js' ); // @codeCoverageIgnore
+			wp_delete_file( $cache_dir . $js_file . '.js' ); // @codeCoverageIgnore
 		}
 
 		if ( $this->dir_is_empty( $cache_dir ) ) {

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -90,7 +90,7 @@ class Cron {
 		 * Some servers don't do a full overwrite if file already exists, so we delete it first.
 		 */
 		if ( file_exists( $local_file ) ) {
-			unlink( $local_file );
+			wp_delete_file( $local_file );
 		}
 
 		$write = file_put_contents( $local_file, wp_remote_retrieve_body( $file_contents ) );

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -136,8 +136,8 @@ class Proxy {
 	 */
 	public function generate_event_url() {
 		$url            = '';
-		$parts          = parse_url( $_SERVER[ 'REQUEST_URI' ] );
-		$home_url_parts = parse_url( get_home_url() );
+		$parts          = wp_parse_url( $_SERVER[ 'REQUEST_URI' ] );
+		$home_url_parts = wp_parse_url( get_home_url() );
 
 		if ( isset( $home_url_parts[ 'scheme' ] ) && isset( $home_url_parts[ 'host' ] ) && isset( $parts[ 'path' ] ) ) {
 			$url = $home_url_parts[ 'scheme' ] . '://' . $home_url_parts [ 'host' ] . $parts[ 'path' ];

--- a/src/Uninstall.php
+++ b/src/Uninstall.php
@@ -62,7 +62,7 @@ class Uninstall {
 		$file_path = WP_CONTENT_DIR . '/mu-plugins/plausible-proxy-speed-module.php';
 
 		if ( file_exists( $file_path ) ) {
-			unlink( $file_path );
+			wp_delete_file( $file_path );
 		}
 	}
 }


### PR DESCRIPTION
Resolves PHPCS warnings for using non-WordPress alternatives.

- plausible-proxy-speed-module.php now uses wp_parse_url()
- Proxy.php and Proxy.php now use wp_parse_url()
- Module.php and Module.php now use wp_delete_file()
- Cron.php now uses wp_delete_file()
- Uninstall.php now uses wp_delete_file()

No functional changes expected.