### PR TITLE
distignore three new files

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,6 +43,9 @@ composer.json
 composer.lock
 npm-shrinkwrap.json
 openapitools.json
+/src/Client/.openapi-generator-ignore
+/src/Client/.php-cs-fixer.dist.php
+/src/Client/git_push.sh
 package.json
 package-lock.json
 phpunit.xml


### PR DESCRIPTION
## Summary
Exclude three development-only files from the plugin distribution:

* `src/Client/.openapi-generator-ignore`
* `src/Client/.php-cs-fixer.dist.php`
* `src/Client/git_push.sh`

## Reason
These files trigger WordPress Plugin Check issues for hidden and application files.

## Testing
* Rebuilt the plugin ZIP
* Confirmed the three files are no longer included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated distribution settings to exclude internal development and tooling files from build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->