### PR TITLE
Missing translator comments

### DIFF
--- a/src/Admin/Settings/API.php
+++ b/src/Admin/Settings/API.php
@@ -649,11 +649,12 @@ class API {
 											<?php $multilang_plugin_name = Helpers::get_multilang_plugin_name(); ?>
 											<div class="plausible-analytics-hook success persist mt-4">
 												<?php printf(
+													/* translators: %s: multilingual plugin name. */
 													esc_html__(
 														"You're using %s with different domains per language. You can map your other language domains to Plausible after completing this wizard in the plugin settings.",
 														'plausible-analytics'
 													),
-													$multilang_plugin_name
+													esc_html( $multilang_plugin_name )
 												); ?>
 											</div>
 										<?php endif; ?>

--- a/src/AdminBar.php
+++ b/src/AdminBar.php
@@ -101,7 +101,11 @@ class AdminBar {
 
 				$args[] = [
 					'id'     => "view-analytics-$key",
-					'title'  => sprintf( esc_html__( 'View analytics for %s', 'plausible-analytics' ), $language_domain ),
+					/* translators: %s: language domain. */
+					'title' => sprintf(
+						esc_html__( 'View analytics for %s', 'plausible-analytics' ),
+						$language_domain
+					),
 					'href'   => $href,
 					'parent' => 'plausible-analytics',
 				];


### PR DESCRIPTION
## Summary
Add translator comments for strings containing placeholders in:
* `src/AdminBar.php`
* `src/Admin/Settings/API.php`

+ fixes a escape issue around the same codeblock, so fixed that as well.

## Reason
Resolves WordPress Plugin Check `MissingTranslatorsComment` issues.

## Testing
* Ran Plugin Check
* Confirmed both warnings are resolved